### PR TITLE
Change es6 shorthand notation to es5 notation

### DIFF
--- a/src/js/browser.js
+++ b/src/js/browser.js
@@ -10,7 +10,7 @@ module.exports = {
   },
 
   // Edge 20+
-  isEdge: function() {
+  isEdge: function () {
     return !this.isIE() && !!window.StyleMedia
   },
 

--- a/src/js/browser.js
+++ b/src/js/browser.js
@@ -10,7 +10,7 @@ module.exports = {
   },
 
   // Edge 20+
-  isEdge() {
+  isEdge: function() {
     return !this.isIE() && !!window.StyleMedia
   },
 


### PR DESCRIPTION
Attempt for fix #30 and https://github.com/facebookincubator/create-react-app/issues/1838
UglifyJS does not understand this notation. It's also not consistent within file so es5 notation should be better for this.
