### PR TITLE
Output as UMD

### DIFF
--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -1,3 +1,11 @@
 const { mix } = require('laravel-mix')
 
 mix.js('src/index.js', 'dist/print.min.js').styles('src/css/print.css', 'dist/print.min.css')
+
+mix.webpackConfig({
+  output: {
+    library: 'print-js',
+    libraryTarget: 'umd',
+    umdNamedDefine: true
+  }
+})


### PR DESCRIPTION
In https://github.com/crabbly/Print.js/pull/103 I modified the entrypoint to be the minified version.  But, when trying to import the new published version in my project, I got an error.

This updates the webpack config to generate a UMD that can be imported by CommonJS, AMD or as a property on root.

I checked by doing a sym link in `node_modules/` to the folder with this branch and this seems to fix it. I also checked including the minified version and it exports it as a global window object correctly.

Sorry for the issue, and thanks for being an active maintainer!

