### PR TITLE
Enhancing the json printable type

### DIFF
--- a/src/js/init.js
+++ b/src/js/init.js
@@ -10,7 +10,7 @@ import Json from './json'
 let printTypes = ['pdf', 'html', 'image', 'json']
 
 export default {
-  init () {
+  init() {
     let params = {
       printable: null,
       fallbackPrintable: null,
@@ -23,7 +23,7 @@ export default {
       honorMarginPadding: true,
       honorColor: false,
       properties: null,
-      gridHeaderStyle: 'font-weight: bold;',
+      gridHeaderStyle: 'font-weight: bold; padding: 5px; border: 1px solid #dddddd;',
       gridStyle: 'border: 1px solid lightgray; margin-bottom: -1px;',
       showModal: false,
       onLoadingStart: null,

--- a/src/js/json.js
+++ b/src/js/json.js
@@ -6,7 +6,6 @@ import Print from './print';
 
 export default {
   print: (params, printFrame) => {
-    console.log(params.printLayout);
 
     // Check if we received proper data
     if (typeof params.printable !== 'object') {

--- a/src/js/json.js
+++ b/src/js/json.js
@@ -1,16 +1,21 @@
-import { addWrapper, capitalizePrint } from './functions'
-import Print from './print'
+import {
+  addWrapper,
+  capitalizePrint
+} from './functions';
+import Print from './print';
 
 export default {
   print: (params, printFrame) => {
+    console.log(params.printLayout);
+
     // Check if we received proper data
     if (typeof params.printable !== 'object') {
-      throw new Error('Invalid javascript data object (JSON).')
+      throw new Error('Invalid javascript data object (JSON).');
     }
 
     // Check if properties were provided
     if (!params.properties || typeof params.properties !== 'object') {
-      throw new Error('Invalid properties array for your JSON data.')
+      throw new Error('Invalid properties array for your JSON data.');
     }
 
     // Variable to hold the html string
@@ -18,60 +23,62 @@ export default {
 
     // Check print has header
     if (params.header) {
-      htmlData += '<h1 style="' + params.headerStyle + '">' + params.header + '</h1>'
+      htmlData += '<h1 style="' + params.headerStyle + '">' + params.header + '</h1>';
     }
 
     // Build html data
-    htmlData += jsonToHTML(params)
+    htmlData += jsonToHTML(params);
 
     // Store html data
-    params.htmlData = addWrapper(htmlData, params)
+    params.htmlData = addWrapper(htmlData, params);
 
     // Print json data
-    Print.send(params, printFrame)
+    Print.send(params, printFrame);
   }
 }
 
-function jsonToHTML (params) {
-  let data = params.printable
-  let properties = params.properties
+function jsonToHTML(params) {
+  let data = params.printable;
+  let properties = params.properties;
 
-  let htmlData = '<div style="display:flex; flex-direction: column;">'
-
-  // Header
-  htmlData += '<div style="flex:1 1 auto; display:flex;">'
-
+  // Defining the report header as repeatable
+  let htmlData = '<table style="border-collapse: collapse; width: 100%;"><thead><tr>';
   for (let a = 0; a < properties.length; a++) {
-    htmlData += '<div style="flex:1; padding:5px;' + params.gridHeaderStyle + '">' + capitalizePrint(properties[a]) + '</div>'
+    htmlData += '<th style="width:' + 100 / properties.length + '%; ' + params.gridHeaderStyle + '">' + capitalizePrint(properties[a]) + '</th>';
   }
+  htmlData += '</tr></thead><tbody>';
 
-  htmlData += '</div>'
-
-  // Data
+  // Adding the table rows
   for (let i = 0; i < data.length; i++) {
-    htmlData += '<div style="flex:1 1 auto; display:flex;">'
+
+    // Adding the starting tag
+    htmlData += '<tr>';
 
     // Print selected properties only
     for (let n = 0; n < properties.length; n++) {
-      let stringData = data[i]
+      let stringData = data[i];
 
-      // Support for nested objects
-      let property = properties[n].split('.')
+      // Adding the support for the nested objects
+      let property = properties[n].split('.');
       if (property.length > 1) {
         for (let p = 0; p < property.length; p++) {
-          stringData = stringData[property[p]]
+          stringData = stringData[property[p]];
         }
       } else {
-        stringData = stringData[properties[n]]
+        stringData = stringData[properties[n]];
       }
 
-      htmlData += '<div style="flex:1; padding:5px;' + params.gridStyle + '">' + stringData + '</div>'
+      // Adding the row contents and styles
+      htmlData += '<td style="width:' + 100 / properties.length + '%;' + params.gridStyle + '">' + stringData + '</td>';
     }
 
-    htmlData += '</div>'
+    // Adding the ending tag
+    htmlData += '</tr>';
   }
 
-  htmlData += '</div>'
+  // Adding the closing tag of the table
+  htmlData += '</tbody></table>';
 
-  return htmlData
+  // Return the structure back to the printer
+  return htmlData;
 }


### PR DESCRIPTION
There were 2 issues which made me update the json printable type:
1. In case of having a large dataset (let's say more than one page), the table column needs to be repeated at the beginning of each page. This was missing.
2. Since the printable is defined as a combination of many `<div>` elements, in case of having a cell in the middle of page with larger contents than the expected size, the cell increases the width rather than increasing the height. This made me change the `<div>` elements to `<table>`. In this branch, this issue resolved and in such cases, the cell will increase the height and not the width.