### PR TITLE
Adding repeatTableHeader attribute for JSON printable

### DIFF
--- a/src/js/init.js
+++ b/src/js/init.js
@@ -35,7 +35,8 @@ export default {
       targetStyle: null,
       targetStyles: null,
       ignoreElements: [],
-      imageStyle: 'width:100%;'
+      imageStyle: 'width:100%;',
+      repeatTableHeader: true
     }
 
     // Check if a printable document or object was supplied
@@ -72,6 +73,7 @@ export default {
         params.targetStyles = typeof args.targetStyles !== 'undefined' ? args.targetStyles : params.targetStyles
         params.ignoreElements = typeof args.ignoreElements !== 'undefined' ? args.ignoreElements : params.ignoreElements
         params.imageStyle = typeof args.imageStyle !== 'undefined' ? args.imageStyle : params.imageStyle
+        params.repeatTableHeader = typeof args.repeatTableHeader !== 'undefined' ? args.repeatTableHeader : params.repeatTableHeader
         break
       default:
         throw new Error('Unexpected argument type! Expected "string" or "object", got ' + typeof args)

--- a/src/js/json.js
+++ b/src/js/json.js
@@ -32,16 +32,35 @@ export default {
 }
 
 function jsonToHTML (params) {
+  // Get the row and column data
   let data = params.printable
   let properties = params.properties
 
   // Create a html table and define the header as repeatable
-  let htmlData = '<table style="border-collapse: collapse; width: 100%;"><thead><tr>'
+  let htmlData = '<table style="border-collapse: collapse; width: 100%;">'
 
+  // Check if the header should be repeated
+  if (params.repeatTableHeader) {
+    htmlData += '<thead>'
+  }
+
+  // Create the table row
+  htmlData += '<tr>'
+
+  // Create a table header for each column
   for (let a = 0; a < properties.length; a++) {
     htmlData += '<th style="width:' + 100 / properties.length + '%; ' + params.gridHeaderStyle + '">' + capitalizePrint(properties[a]) + '</th>'
   }
 
+  // Add the closing tag for the table row
+  htmlData += '</tr>'
+
+  // Check if the table header is marked as repeated, then add the closing tag
+  if (params.repeatTableHeader) {
+    htmlData += '</thead>'
+  }
+
+  // Add the closing tag for the table body
   htmlData += '</tr></thead><tbody>'
 
   // Add the table rows

--- a/src/js/json.js
+++ b/src/js/json.js
@@ -11,13 +11,18 @@ export default {
       throw new Error('Invalid javascript data object (JSON).')
     }
 
+    // Check if the repeatTableHeader is boolean
+    if (typeof params.repeatTableHeader !== 'boolean') {
+      throw new Error('Invalid value for repeatTableHeader attribute (JSON).')
+    }
+
     // Check if properties were provided
     if (!params.properties || typeof params.properties !== 'object') throw new Error('Invalid properties array for your JSON data.')
 
     // Variable to hold the html string
     let htmlData = ''
 
-    // Check if we are adding a header
+    // Check if there is a header on top of the table
     if (params.header) htmlData += '<h1 style="' + params.headerStyle + '">' + params.header + '</h1>'
 
     // Build html data


### PR DESCRIPTION
By default all tableHeaders in JSON printableType will be repeated in each page but in case the user doesn't need this, the repeatTableHeader attribute can be set to false.