### PR TITLE
Add custom css support (including media print)

### DIFF
--- a/src/js/init.js
+++ b/src/js/init.js
@@ -36,7 +36,8 @@ export default {
       targetStyles: null,
       ignoreElements: [],
       imageStyle: 'width:100%;',
-      repeatTableHeader: true
+      repeatTableHeader: true,
+      css: null
     }
 
     // Check if a printable document or object was supplied
@@ -74,6 +75,7 @@ export default {
         params.ignoreElements = typeof args.ignoreElements !== 'undefined' ? args.ignoreElements : params.ignoreElements
         params.imageStyle = typeof args.imageStyle !== 'undefined' ? args.imageStyle : params.imageStyle
         params.repeatTableHeader = typeof args.repeatTableHeader !== 'undefined' ? args.repeatTableHeader : params.repeatTableHeader
+        params.css = typeof args.css !== 'undefined' ? args.css : params.css
         break
       default:
         throw new Error('Unexpected argument type! Expected "string" or "object", got ' + typeof args)

--- a/src/js/print.js
+++ b/src/js/print.js
@@ -24,6 +24,16 @@ const Print = {
           // Inject printable html into iframe body
           printDocument.body.innerHTML = params.htmlData
 
+          // Add custom css
+          if (params.css !== null && params.css !== '') {
+            // Create style element
+            const style = document.createElement('style')
+            style.append(params.css)
+
+            // Append style element to iframe's head
+            printDocument.head.append(style)
+          }
+
           // If printing image, wait for it to load inside the iframe (skip firefox)
           if (params.type === 'image') {
             loadIframeImages(printDocument, params).then(() => {

--- a/test.html
+++ b/test.html
@@ -6,7 +6,24 @@
     }
 
     function printHtml() {
-      printJS('test', 'html');
+      printJS({
+        printable: 'test',
+        type: 'html'
+      });
+    }
+
+    function printHtmlCustom() {
+      const css = `
+        @page {
+          margin: 0
+        }
+      `
+
+      printJS({
+        printable: 'test',
+        type: 'html',
+        css: css
+      });
     }
 
     function printJson() {
@@ -36,6 +53,9 @@
       </button>
       <button onClick='printHtml();'>
         Print HTML
+      </button>
+      <button onClick='printHtmlCustom();'>
+        Print HTML with custom css
       </button>
       <button onClick='printJson();'>
         Print JSON


### PR DESCRIPTION
Since there wasn't any way to use `@media print` and/or any custom css specific for printing, i tried my hand at adding that function.
Pass a string to `css` parameter and that's it.
Thanks for the library, but it really needs that =)