### PR TITLE
Add array of external css parameter, and option to disable css scanning

### DIFF
--- a/src/js/html.js
+++ b/src/js/html.js
@@ -26,13 +26,17 @@ export default {
     printableElement = document.getElementById('printJS-html')
 
     // Get main element styling
-    printableElement.setAttribute('style', collectStyles(printableElement, params) + 'margin:0 !important;')
+    if (params.scanStyles === true) {
+      printableElement.setAttribute('style', collectStyles(printableElement, params) + 'margin:0 !important;')
+    }
 
     // Get all children elements
     let elements = printableElement.children
 
     // Get styles for all children elements
-    loopNodesCollectStyles(elements, params)
+    if (params.scanStyles === true) {
+      loopNodesCollectStyles(elements, params)
+    }
 
     // Add header if any
     if (params.header) {

--- a/src/js/init.js
+++ b/src/js/init.js
@@ -37,7 +37,9 @@ export default {
       ignoreElements: [],
       imageStyle: 'width:100%;',
       repeatTableHeader: true,
-      css: null
+      css: null,
+      externalCss: [],
+      scanStyles: true
     }
 
     // Check if a printable document or object was supplied
@@ -76,6 +78,8 @@ export default {
         params.imageStyle = typeof args.imageStyle !== 'undefined' ? args.imageStyle : params.imageStyle
         params.repeatTableHeader = typeof args.repeatTableHeader !== 'undefined' ? args.repeatTableHeader : params.repeatTableHeader
         params.css = typeof args.css !== 'undefined' ? args.css : params.css
+        params.externalCss = typeof args.externalCss !== 'undefined' ? args.externalCss : params.externalCss
+        params.scanStyles = typeof args.scanStyles !== 'undefined' ? args.scanStyles : params.scanStyles
         break
       default:
         throw new Error('Unexpected argument type! Expected "string" or "object", got ' + typeof args)

--- a/src/js/print.js
+++ b/src/js/print.js
@@ -27,7 +27,7 @@ const Print = {
           // Add external css
           if (params.externalCss !== null && Array.isArray(params.externalCss)) {
             for (let index = 0; index < params.externalCss.length; index++) {
-              const styleLink = params.externalCss[index];
+              const styleLink = params.externalCss[index]
               const cssLink = document.createElement('link')
               cssLink.rel = 'stylesheet'
               cssLink.href = styleLink

--- a/src/js/print.js
+++ b/src/js/print.js
@@ -24,6 +24,19 @@ const Print = {
           // Inject printable html into iframe body
           printDocument.body.innerHTML = params.htmlData
 
+          // Add external css
+          if (params.externalCss !== null && Array.isArray(params.externalCss)) {
+            for (let index = 0; index < params.externalCss.length; index++) {
+              const styleLink = params.externalCss[index];
+              const cssLink = document.createElement('link')
+              cssLink.rel = 'stylesheet'
+              cssLink.href = styleLink
+
+              // Append style link element to iframe's head
+              printDocument.head.append(cssLink)
+            }
+          }
+
           // Add custom css
           if (params.css !== null && params.css !== '') {
             // Create style element

--- a/test.html
+++ b/test.html
@@ -22,7 +22,8 @@
       printJS({
         printable: 'test',
         type: 'html',
-        css: css
+        css: css,
+        scanStyles: false
       });
     }
 
@@ -46,7 +47,7 @@
     }
   </script>
   <body>
-    <section id="test">
+    <section id="test" class="test">
       <h1>Print.js Test Page</h1>
       <button onClick='printPdf();'>
         Print PDF


### PR DESCRIPTION
I added the option to add external css files urls as an array parameter externalCss
For example `externalCss: ['https://stackpath.bootstrapcdn.com/bootstrap/4.1.1/css/bootstrap.min.css']`
Also the boolean parameter scanStyles for toggling the scanning and inlining of the elements css.
I think we should keep all the options available for any use cases, for example I like the scanning of the css but would like to add `@media print` for page margin or some small stuff, which I would like to just put as a small string instead of it's own file or whatever. Also I think it's more useful for frontend framework users (or I'm too dumb to find how to, so I'll use it simply like that :))