### PR TITLE
Add onPrintDialogClose callback option

### DIFF
--- a/src/js/functions.js
+++ b/src/js/functions.js
@@ -57,8 +57,8 @@ export function loopNodesCollectStyles (elements, params) {
 
       // Get text value
       let textNode = tag === 'SELECT'
-                ? document.createTextNode(currentElement.options[currentElement.selectedIndex].text)
-                : document.createTextNode(currentElement.value)
+        ? document.createTextNode(currentElement.options[currentElement.selectedIndex].text)
+        : document.createTextNode(currentElement.value)
 
       // Create text element
       let textElement = document.createElement('div')

--- a/src/js/init.js
+++ b/src/js/init.js
@@ -28,6 +28,7 @@ export default {
       showModal: false,
       onLoadingStart: null,
       onLoadingEnd: null,
+      onPrintDialogClose: null,
       modalMessage: 'Retrieving Document...',
       frameId: 'printJS',
       htmlData: '',
@@ -70,6 +71,7 @@ export default {
         params.showModal = typeof args.showModal !== 'undefined' ? args.showModal : params.showModal
         params.onLoadingStart = typeof args.onLoadingStart !== 'undefined' ? args.onLoadingStart : params.onLoadingStart
         params.onLoadingEnd = typeof args.onLoadingEnd !== 'undefined' ? args.onLoadingEnd : params.onLoadingEnd
+        params.onPrintDialogClose = typeof args.onPrintDialogClose !== 'undefined' ? args.onPrintDialogClose : params.onPrintDialogClose
         params.modalMessage = typeof args.modalMessage !== 'undefined' ? args.modalMessage : params.modalMessage
         params.documentTitle = typeof args.documentTitle !== 'undefined' ? args.documentTitle : params.documentTitle
         params.targetStyle = typeof args.targetStyle !== 'undefined' ? args.targetStyle : params.targetStyle

--- a/src/js/pdf.js
+++ b/src/js/pdf.js
@@ -36,6 +36,6 @@ export default {
 function send (params, printFrame) {
   // Set iframe src with pdf document url
   printFrame.setAttribute('src', params.printable)
-
+  console.log('', params)
   Print.send(params, printFrame)
 }

--- a/src/js/pdf.js
+++ b/src/js/pdf.js
@@ -4,8 +4,8 @@ export default {
   print: (params, printFrame) => {
     // Format pdf url
     params.printable = params.printable.indexOf('http') !== -1
-        ? params.printable
-        : window.location.origin + (params.printable.charAt(0) !== '/' ? '/' + params.printable : params.printable)
+      ? params.printable
+      : window.location.origin + (params.printable.charAt(0) !== '/' ? '/' + params.printable : params.printable)
 
     // If showing a loading modal or using a hook function, we will preload the pdf file
     if (params.showModal || params.onLoadingStart) {

--- a/src/js/print.js
+++ b/src/js/print.js
@@ -71,6 +71,23 @@ function finishPrint (iframeElement, params) {
 
   // If preloading pdf files, clean blob url
   if (params.showModal || params.onLoadingStart) window.URL.revokeObjectURL(params.printable)
+  
+  // If a onPrintDialogClose callback is given, execute it
+  if (params.onPrintDialogClose) {
+    if (!Browser.isFirefox()) {
+      const handler = () => {
+        // Make sure the event only happens once.
+        window.removeEventListener('mouseover', handler)
+        
+        params.onPrintDialogClose()
+      }
+      
+      window.addEventListener('mouseover', handler)
+    } else {
+      console.warn('onPrintDialogClose callback does not work with Firefox browser. For further details see https://www.google.co.cr/')
+    }
+  }
+
 }
 
 function loadIframeImages (printDocument, params) {

--- a/src/js/print.js
+++ b/src/js/print.js
@@ -71,23 +71,22 @@ function finishPrint (iframeElement, params) {
 
   // If preloading pdf files, clean blob url
   if (params.showModal || params.onLoadingStart) window.URL.revokeObjectURL(params.printable)
-  
+
   // If a onPrintDialogClose callback is given, execute it
   if (params.onPrintDialogClose) {
     if (!Browser.isFirefox()) {
       const handler = () => {
         // Make sure the event only happens once.
         window.removeEventListener('mouseover', handler)
-        
+
         params.onPrintDialogClose()
       }
-      
+
       window.addEventListener('mouseover', handler)
     } else {
-      console.warn('onPrintDialogClose callback does not work with Firefox browser. For further details see https://www.google.co.cr/')
+      console.warn('onPrintDialogClose callback does not work with Firefox browser. For further details see https://github.com/crabbly/Print.js/pull/191')
     }
   }
-
 }
 
 function loadIframeImages (printDocument, params) {

--- a/src/js/print.js
+++ b/src/js/print.js
@@ -74,18 +74,21 @@ function finishPrint (iframeElement, params) {
 
   // If a onPrintDialogClose callback is given, execute it
   if (params.onPrintDialogClose) {
-    if (!Browser.isFirefox()) {
-      const handler = () => {
-        // Make sure the event only happens once.
-        window.removeEventListener('mouseover', handler)
+    let event = 'mouseover'
 
-        params.onPrintDialogClose()
-      }
-
-      window.addEventListener('mouseover', handler)
-    } else {
-      console.warn('onPrintDialogClose callback does not work with Firefox browser. For further details see https://github.com/crabbly/Print.js/pull/191')
+    if (Browser.isChrome() || Browser.isFirefox()) {
+      // Firefox will require an extra click in the document
+      // to fire the focus event. Should we console.warn that?
+      event = 'focus'
     }
+    const handler = () => {
+      // Make sure the event only happens once.
+      window.removeEventListener(event, handler)
+
+      params.onPrintDialogClose()
+    }
+
+    window.addEventListener(event, handler)
   }
 }
 

--- a/test.html
+++ b/test.html
@@ -12,6 +12,15 @@
             showModal: true
         });
     }
+    
+    function printPdfWithModalAndCloseCallback() {
+        printJS({
+            printable: 'test.pdf',
+            type: 'pdf',
+            showModal: true,
+            onPrintDialogClose: () => console.log('The print dialog was closed')
+        });
+    }
 
     function printHtml() {
       printJS({
@@ -126,6 +135,9 @@
         </button>
         <button onClick='printPdfWithModal();'>
           Print PDF with Loading Modal
+        </button>
+        <button onClick='printPdfWithModalAndCloseCallback();'>
+          Print PDF with Loading Modal and close callback
         </button>
       </p>
       <p>


### PR DESCRIPTION
This option enables print "completion" notification, when possible.
Note that these implementation is somehow weak as we don't currently
have a way to know whether the user printed the document or not, so
the use of "print completion notification" is misleading.

Another issue to highlight is that this implementation depends upon
window's mouseover event, this means that, while the print dialog
is open, the window does not have the focus and thus, the mouseover
event will not be fired. However, this is not the case for Firefox,
because the print dialog does not removes the focus from window.

Last, the implementation is inspired in StackOverflow's thread [how
to detech window.print() finish](https://stackoverflow.com/q/18325025)
and the two responses https://stackoverflow.com/a/35430328 and
https://stackoverflow.com/a/45625229