### PR TITLE
Support for multiple tables in json printable

### DIFF
--- a/src/js/init.js
+++ b/src/js/init.js
@@ -13,6 +13,7 @@ export default {
   init () {
     let params = {
       printable: null,
+      multiplePrintable: null,
       fallbackPrintable: null,
       type: 'pdf',
       header: null,
@@ -82,13 +83,11 @@ export default {
         params.css = typeof args.css !== 'undefined' ? args.css : params.css
         params.style = typeof args.style !== 'undefined' ? args.style : params.style
         params.scanStyles = typeof args.scanStyles !== 'undefined' ? args.scanStyles : params.scanStyles
+        params.multiplePrintable = typeof args.multiplePrintable !== 'undefined' ? args.multiplePrintable : params.multiplePrintable
         break
       default:
         throw new Error('Unexpected argument type! Expected "string" or "object", got ' + typeof args)
     }
-
-    // Validate printable
-    if (!params.printable) throw new Error('Missing printable information.')
 
     // Validate type
     if (!params.type || typeof params.type !== 'string' || printTypes.indexOf(params.type.toLowerCase()) === -1) {

--- a/src/js/json.js
+++ b/src/js/json.js
@@ -6,18 +6,20 @@ import Print from './print'
 
 export default {
   print: (params, printFrame) => {
-    // Check if we received proper data
-    if (typeof params.printable !== 'object') {
-      throw new Error('Invalid javascript data object (JSON).')
-    }
+    // If both single and multiple tables are requested at the same time, throw an error
+    if (params.printable && params.multiplePrintable) throw new Error('Only one printable type (single or multiple) can be processed at the same time.')
 
-    // Check if the repeatTableHeader is boolean
-    if (typeof params.repeatTableHeader !== 'boolean') {
-      throw new Error('Invalid value for repeatTableHeader attribute (JSON).')
-    }
+    // In case of single table, check if the data structure is correct
+    if (params.printable && typeof params.printable !== 'object') throw new Error('Invalid javascript data object (JSON) for single table.')
 
     // Check if properties were provided
-    if (!params.properties || !Array.isArray(params.properties)) throw new Error('Invalid properties array for your JSON data.')
+    if (params.printable && (!params.properties || !Array.isArray(params.properties))) throw new Error('Invalid properties array for your JSON data.')
+
+    // In case of multiple table, check if the data structure is correct
+    if (params.multiplePrintable && typeof params.multiplePrintable !== 'object') throw new Error('Invalid javascript data object (JSON) for multiple table.')
+
+    // Check if the repeatTableHeader is boolean
+    if (typeof params.repeatTableHeader !== 'boolean') throw new Error('Invalid value for repeatTableHeader attribute (JSON).')
 
     // Variable to hold the html string
     let htmlData = ''
@@ -37,66 +39,102 @@ export default {
 }
 
 function jsonToHTML (params) {
-  // Get the row and column data
-  let data = params.printable
-  let properties = params.properties
+  // Define an empty holder for the htmldata
+  let htmlData = ''
 
-  // Create a html table
-  let htmlData = '<table style="border-collapse: collapse; width: 100%;">'
+  // Check if the print is supposed to be with multiple tables
+  if (params.multiplePrintable === null) {
+    // Create an array of objects for the single table
+    let dataset = [{
+      // headerName: params.headerName,
+      properties: params.properties,
+      printable: params.printable
+    }]
 
-  // Check if the header should be repeated
-  if (params.repeatTableHeader) {
-    htmlData += '<thead>'
+    // Pass the dataset to the html table creater
+    htmlData = createHtmlTable(params, dataset)
+  } else {
+    htmlData += createHtmlTable(params, params.multiplePrintable)
   }
+  return htmlData
+}
 
-  // Add the table header row
-  htmlData += '<tr>'
+/**
+ * Function to create the html table(s).
+ * @param  {object} params parameters list which needs to be considered while generating the table.
+ * @param  {array} dataset the array containing the dataset which needs to be converted to a table.
+ */
+function createHtmlTable (params, dataset) {
+  // Defining the htmlTable holder
+  let htmlData = ''
 
-  // Add the table header columns
-  for (let a = 0; a < properties.length; a++) {
-    htmlData += '<th style="width:' + properties.columnSize / properties.length + '%; ' + params.gridHeaderStyle + '">' + capitalizePrint(properties[a].displayName) + '</th>'
-  }
+  // Loop through the multiple printable
+  for (let idx in dataset) {
+    // Retrieve the object from the array
+    let tableObj = dataset[idx]
 
-  // Add the closing tag for the table header row
-  htmlData += '</tr>'
+    // Get the row and column data
+    let data = tableObj.printable
+    let properties = tableObj.properties
 
-  // If the table header is marked as repeated, add the closing tag
-  if (params.repeatTableHeader) {
-    htmlData += '</thead>'
-  }
+    // Create a html table
+    htmlData += '<br><table style="border-collapse: collapse; width: 100%;">'
 
-  // Create the table body
-  htmlData += '<tbody>'
-
-  // Add the table data rows
-  for (let i = 0; i < data.length; i++) {
-    // Add the row starting tag
-    htmlData += '<tr>'
-
-    // Print selected properties only
-    for (let n = 0; n < properties.length; n++) {
-      let stringData = data[i]
-
-      // Support nested objects
-      let property = properties[n].field.split('.')
-      if (property.length > 1) {
-        for (let p = 0; p < property.length; p++) {
-          stringData = stringData[property[p]]
-        }
-      } else {
-        stringData = stringData[properties[n].field]
-      }
-
-      // Add the row contents and styles
-      htmlData += '<td style="width:' + properties[n].columnSize / properties.length + '%;' + params.gridStyle + '">' + stringData + '</td>'
+    // Check if the header should be repeated
+    if (params.repeatTableHeader) {
+      htmlData += '<thead>'
     }
 
-    // Add the row closing tag
+    // Add the table header row
+    htmlData += '<tr>'
+
+    // Add the table header columns
+    for (let a = 0; a < properties.length; a++) {
+      htmlData += '<th style="width:' + (properties[a].columnSize * 100) + '%; ' + params.gridHeaderStyle + '">' + capitalizePrint(properties[a].displayName) + '</th>'
+    }
+
+    // Add the closing tag for the table header row
     htmlData += '</tr>'
+
+    // If the table header is marked as repeated, add the closing tag
+    if (params.repeatTableHeader) {
+      htmlData += '</thead>'
+    }
+
+    // Create the table body
+    htmlData += '<tbody>'
+
+    // Add the table data rows
+    for (let i = 0; i < data.length; i++) {
+      // Add the row starting tag
+      htmlData += '<tr>'
+
+      // Print selected properties only
+      for (let n = 0; n < properties.length; n++) {
+        let stringData = data[i]
+
+        // Support nested objects
+        let property = properties[n].field.split('.')
+        if (property.length > 1) {
+          for (let p = 0; p < property.length; p++) {
+            stringData = stringData[property[p]]
+          }
+        } else {
+          stringData = stringData[properties[n].field]
+        }
+
+        // Add the row contents and styles
+        htmlData += '<td style="width:' + (properties[n].columnSize * 100) + '%;' + params.gridStyle + '">' + stringData + '</td>'
+      }
+
+      // Add the row closing tag
+      htmlData += '</tr>'
+    }
+
+    // Add the table and body closing tags
+    htmlData += '</tbody></table>'
   }
 
-  // Add the table and body closing tags
-  htmlData += '</tbody></table>'
-
+  // Return the table
   return htmlData
 }

--- a/test.html
+++ b/test.html
@@ -18,7 +18,9 @@
             printable: 'test.pdf',
             type: 'pdf',
             showModal: true,
-            onPrintDialogClose: () => console.log('The print dialog was closed')
+            onPrintDialogClose: function(){
+              console.log('The print dialog was closed')
+            }
         });
     }
 
@@ -86,7 +88,66 @@
             }
         ]
 
-        printJS({printable: data, properties: ['test1', 'test2'], type: 'json', gridStyle: 'border: 2px solid #3971A5;', gridHeaderStyle: 'color: red;  border: 2px solid #3971A5;'})
+        printJS({printable: data, properties: [{
+              field: 'test1',
+              displayName: 'test 1',
+              columnSize: 0.25
+            },{
+              field: 'test2',
+              displayName: 'test 2',
+              columnSize: 0.75
+            }], type: 'json', gridStyle: 'border: 2px solid #3971A5;', gridHeaderStyle: 'color: red;  border: 2px solid #3971A5;'})
+    }
+
+    function printMultipleTabularJson() {
+      let data = [];
+      for (let i=0; i <= 1000; i++){
+        data.push({
+          test1: createRandomString(),
+          test2: createRandomString(),
+          test2: createRandomString()
+        });
+      }
+
+      printJS(
+        {
+          multiplePrintable: [{
+            headerName: 'test table 1',
+            properties: [{
+              field: 'test1',
+              displayName: 'test 1',
+              columnSize: 0.25
+            },{
+              field: 'test2',
+              displayName: 'test 2',
+              columnSize: 0.75
+            }],
+            printable: [{
+              test1: 'dasdasdasd',
+              test2: 'afsdfsdf'
+            },{
+              test1: 'jkljlkjk',
+              test2: 'ppkk'
+            }]
+          }, {
+            headerName: 'test table 1',
+            properties: [{
+              field: 'test1',
+              displayName: 'test 1',
+              columnSize: 0.25
+            },{
+              field: 'test2',
+              displayName: 'test 2',
+              columnSize: 0.50
+            },{
+              field: 'test2',
+              displayName: 'test 2',
+              columnSize: 0.25
+            }],
+            printable: data
+          }],
+          type: 'json'
+        })
     }
 
     function printNestedJson() {
@@ -160,6 +221,9 @@
         </button>
         <button onClick='printNestedJson();'>
           Print Nested JSON
+        </button>
+        <button onClick='printMultipleTabularJson();'>
+          Print Multiple Table Json
         </button>
       </p>
     </section>


### PR DESCRIPTION
There was a use case where I needed to have multiple tables with different columns in a json printable. Therefore this made me to create an additional parameter called `multiplePrintable` where we can add an array of objects containing the same structure as in previous `printable`.

No worries for the conflict as there are quite a few checks to make sure that we only process one printable at the same time.

I have also updated the test file and added a new button for multiple print. I have also checked the functionality on Safari 11.1.1, Chrome 67.0.3396.99, FireFox 61.0.1, Opera 54.0 and IE11.0.9600.17843. All seem to be fine.