### PR TITLE
improve object url handling

### DIFF
--- a/src/js/pdf.js
+++ b/src/js/pdf.js
@@ -3,7 +3,7 @@ import Print from './print'
 export default {
   print: (params, printFrame) => {
     // Format pdf url
-    params.printable = params.printable.indexOf('http') !== -1
+    params.printable = /^(blob|http)/i.test(params.printable)
       ? params.printable
       : window.location.origin + (params.printable.charAt(0) !== '/' ? '/' + params.printable : params.printable)
 


### PR DESCRIPTION
Currently, object URLs created on a file:// origin are not handled correctly, resulting in an additional origin prefix and rendering the object URL invalid. This PR treats URLs starting with either http or blob as complete.