### PR TITLE
Fix "Can't resolve 'print-js'" build error

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "homepage": "http://printjs.crabbly.com",
   "description": "A tiny javascript library to help printing from the web.",
   "version": "1.0.49",
-  "main": "dist/print.js",
+  "main": "dist/print.min.js",
   "repository": "https://github.com/crabbly/Print.js",
   "license": "MIT",
   "dependences": {},


### PR DESCRIPTION
When I use `npm link` to include a local version of `print-js`, webpack fails with the error "Can't resolve 'print-js'".  This is because `npm run dev` creates `dist/print.min.js` but the `package.json` advertises `dist/print.js` as the entry point.

Fixing that build error by setting package.json's `main` field to the file that webpack builds.
