### PR TITLE
Added onPdfOpen callback option

### DIFF
--- a/src/js/init.js
+++ b/src/js/init.js
@@ -29,6 +29,7 @@ export default {
       onLoadingStart: null,
       onLoadingEnd: null,
       onPrintDialogClose: null,
+      onPdfOpen: null,
       modalMessage: 'Retrieving Document...',
       frameId: 'printJS',
       htmlData: '',
@@ -72,6 +73,7 @@ export default {
         params.onLoadingStart = typeof args.onLoadingStart !== 'undefined' ? args.onLoadingStart : params.onLoadingStart
         params.onLoadingEnd = typeof args.onLoadingEnd !== 'undefined' ? args.onLoadingEnd : params.onLoadingEnd
         params.onPrintDialogClose = typeof args.onPrintDialogClose !== 'undefined' ? args.onPrintDialogClose : params.onPrintDialogClose
+        params.onPdfOpen = typeof args.onPdfOpen !== 'undefined' ? args.onPdfOpen : params.onPdfOpen
         params.modalMessage = typeof args.modalMessage !== 'undefined' ? args.modalMessage : params.modalMessage
         params.documentTitle = typeof args.documentTitle !== 'undefined' ? args.documentTitle : params.documentTitle
         params.targetStyle = typeof args.targetStyle !== 'undefined' ? args.targetStyle : params.targetStyle
@@ -147,6 +149,7 @@ export default {
           // Make sure there is no loading modal opened
           if (params.showModal) Modal.close()
           if (params.onLoadingEnd) params.onLoadingEnd()
+          if (params.onPdfOpen) params.onPdfOpen()
         } else {
           Pdf.print(params, printFrame)
         }

--- a/test.html
+++ b/test.html
@@ -18,7 +18,8 @@
             printable: 'test.pdf',
             type: 'pdf',
             showModal: true,
-            onPrintDialogClose: () => console.log('The print dialog was closed')
+            onPrintDialogClose: () => console.log('The print dialog was closed'),
+            onPdfOpen: () => console.log('Pdf was opened in a new tab due to an incompatible browser')
         });
     }
 


### PR DESCRIPTION
To work similarly to the onPrintDialogClose callback, but for when the pdf is opened in a new tab for Firefox/Edge/IE