### PR TITLE
Fix bug that stopped images from printing.

### DIFF
--- a/src/js/print.js
+++ b/src/js/print.js
@@ -102,15 +102,16 @@ function loadIframeImages (printDocument, params) {
 
 function loadIframeImage (printDocument, index) {
   return new Promise(resolve => {
-    let image = printDocument ? printDocument.getElementById('printableImage' + index) : null
+    const pollImage = () => {
+      let image = printDocument ? printDocument.getElementById('printableImage' + index) : null
 
-    if (!image || typeof image.naturalWidth === 'undefined' || image.naturalWidth === 0) {
-      setTimeout(() => {
-        loadIframeImage(printDocument, index)
-      }, 500)
-    } else {
-      resolve()
+      if (!image || typeof image.naturalWidth === 'undefined' || image.naturalWidth === 0) {
+        setTimeout(pollImage, 500)
+      } else {
+        resolve()
+      }
     }
+    pollImage()
   })
 }
 


### PR DESCRIPTION
This bug caused the image to not print unless it was already loaded when `loadIframeImage()` was first called.  Otherwise any subsequent calls to `loadIframeImage()` would create a new promise and then resolve that new promise -- instead of resolving the original promise that was being waited on by the `Promise.all()` returned by `loadIframeImages()`.

I tested before and after my change on Linux Chrome, Linux Firefox, Windows 10 Edge, and Windows 10 IE11.  Interestingly, it worked pretty reliably on IE11 and Firefox *before* the fix.  It usually failed on Chrome and Edge before the fix.