### PR TITLE
Add new onError callback param that receives errors from async code.

### DIFF
--- a/src/js/init.js
+++ b/src/js/init.js
@@ -143,12 +143,17 @@ export default {
       case 'pdf':
         // Check browser support for pdf and if not supported we will just open the pdf file instead
         if (Browser.isFirefox() || Browser.isEdge() || Browser.isIE()) {
-          console.info('PrintJS currently doesn\'t support PDF printing in Firefox, Internet Explorer and Edge.')
-          let win = window.open(params.fallbackPrintable, '_blank')
-          win.focus()
-          // Make sure there is no loading modal opened
-          if (params.showModal) Modal.close()
-          if (params.onLoadingEnd) params.onLoadingEnd()
+          try {
+            console.info('PrintJS currently doesn\'t support PDF printing in Firefox, Internet Explorer and Edge.')
+            let win = window.open(params.fallbackPrintable, '_blank')
+            win.focus()
+          } catch (e) {
+            params.onError(e);
+          } finally {
+            // Make sure there is no loading modal opened
+            if (params.showModal) Modal.close()
+            if (params.onLoadingEnd) params.onLoadingEnd()
+          }
         } else {
           Pdf.print(params, printFrame)
         }

--- a/src/js/init.js
+++ b/src/js/init.js
@@ -26,6 +26,7 @@ export default {
       gridHeaderStyle: 'font-weight: bold; padding: 5px; border: 1px solid #dddddd;',
       gridStyle: 'border: 1px solid lightgray; margin-bottom: -1px;',
       showModal: false,
+      onError: (error) => { throw error },
       onLoadingStart: null,
       onLoadingEnd: null,
       onPrintDialogClose: null,
@@ -69,6 +70,7 @@ export default {
         params.gridHeaderStyle = typeof args.gridHeaderStyle !== 'undefined' ? args.gridHeaderStyle : params.gridHeaderStyle
         params.gridStyle = typeof args.gridStyle !== 'undefined' ? args.gridStyle : params.gridStyle
         params.showModal = typeof args.showModal !== 'undefined' ? args.showModal : params.showModal
+        params.onError = typeof args.onError !== 'undefined' ? args.onError : params.onError
         params.onLoadingStart = typeof args.onLoadingStart !== 'undefined' ? args.onLoadingStart : params.onLoadingStart
         params.onLoadingEnd = typeof args.onLoadingEnd !== 'undefined' ? args.onLoadingEnd : params.onLoadingEnd
         params.onPrintDialogClose = typeof args.onPrintDialogClose !== 'undefined' ? args.onPrintDialogClose : params.onPrintDialogClose

--- a/src/js/init.js
+++ b/src/js/init.js
@@ -148,7 +148,7 @@ export default {
             let win = window.open(params.fallbackPrintable, '_blank')
             win.focus()
           } catch (e) {
-            params.onError(e);
+            params.onError(e)
           } finally {
             // Make sure there is no loading modal opened
             if (params.showModal) Modal.close()

--- a/src/js/print.js
+++ b/src/js/print.js
@@ -96,11 +96,11 @@ function cleanUp (params) {
 
 function finishPrint (iframeElement, params) {
   try {
-    performPrint(iframeElement, params);
-  } catch(error) {
-    params.onError(error);
+    performPrint(iframeElement, params)
+  } catch (error) {
+    params.onError(error)
   } finally {
-    cleanUp(params);
+    cleanUp(params)
   }
 }
 

--- a/src/js/print.js
+++ b/src/js/print.js
@@ -48,7 +48,7 @@ const Print = {
   }
 }
 
-function finishPrint (iframeElement, params) {
+function performPrint (iframeElement, params) {
   iframeElement.focus()
 
   // If Edge or IE, try catch with execCommand
@@ -62,7 +62,9 @@ function finishPrint (iframeElement, params) {
     // Other browsers
     iframeElement.contentWindow.print()
   }
+}
 
+function cleanUp (params) {
   // If we are showing a feedback message to user, remove it
   if (params.showModal) Modal.close()
 
@@ -89,6 +91,16 @@ function finishPrint (iframeElement, params) {
     }
 
     window.addEventListener(event, handler)
+  }
+}
+
+function finishPrint (iframeElement, params) {
+  try {
+    performPrint(iframeElement, params);
+  } catch(error) {
+    params.onError(error);
+  } finally {
+    cleanUp(params);
   }
 }
 


### PR DESCRIPTION
Also clean up the modal when an error is passed to `onError`.

I am not trying to catch all errors.  That would be a big project!  But hopefully catching some errors is an imprevement and additional error catching can be added incrementally.

Does it seem right to call `onLoadingEnd` when an error happened?

Test cases:
* [x] Image. Success case (Firefox).
* [x] HTML. Success case (Chrome).
* [x] JSON
* [ ] PDF
  * [ ] Raise an error in iframe printing by turning this on: chrome://settings/content/pdfDocuments?search=PDF
	* [x] With `onError` parameter
	  * [x] Chrome
	* [x] No `onError` parameter
	  * [x] Chrome
  * [ ] Raise an error in pop-up code by blocking pop-up windows:
	* [ ] With `onError` parameter
	  * [x] Firefox
	  * [x] IE11
	  * [x] Edge
	* [ ] No `onError` parameter passed in
	  * [x] Firefox
	  * [ ] IE11
	  * [ ] Edge
  * [x] Print with no error:
	* [ ] With `onError` parameter
	  * [x] Chrome Linux.
	  * [ ] Safari
	  * [x] Firefox Linux.
	  * [x] IE11 Windows 10.
	  * [x] Edge Windows 10
	* [ ] No `onError` parameter
	  * [ ] Chrome Linux
	  * [ ] Safari
	  * [x] Firefox Linux.
	  * [ ] IE11 Windows 10.
	  * [ ] Edge Windows 10

