### PR TITLE
Fix undefined default export

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,6 +8,8 @@ module.exports = {
     './src/index.js'
   ],
   output: {
+    library: 'printJs',
+    libraryTarget: 'umd',
     path: path.resolve(__dirname, 'dist'),
     filename: 'print.js',
     sourceMapFilename: 'print.map'


### PR DESCRIPTION
Tell Webpack to that this is a library.

This fixes the following error when calling `printJS()` after importing it via `import printJS from 'print-js'`:
> TypeError: __WEBPACK_IMPORTED_MODULE_2_print_js___default(...) is not a function