### PR TITLE
Properly support `window.printJS` and module `print`

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ yarn add print-js
 When installing via npm or yarn, import the library into your project:
 
 ```
-import printJS from 'print-js'
+import print from 'print-js'
 ```
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ yarn add print-js
 When installing via npm or yarn, import the library into your project:
 
 ```
-import print from 'print-js'
+import printJS from 'print-js'
 ```
 
 ## Documentation

--- a/index.d.ts
+++ b/index.d.ts
@@ -30,6 +30,6 @@ export interface Configuration {
   scanStyles?: boolean;
 }
 
-declare var print: (params: string | Configuration) => void;
+declare var printJS: (params: string | Configuration) => void;
 
-export default print;
+export default printJS;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,3 @@
-import 'print-js/dist/print';
-
 declare type PrintTypes = 'pdf' | 'html' | 'image' | 'json';
 
 export interface Configuration {
@@ -32,6 +30,6 @@ export interface Configuration {
   scanStyles?: boolean;
 }
 
-declare var printJS: (params: string | Configuration) => void;
+declare var print: (params: string | Configuration) => void;
 
-export default printJS;
+export default print;

--- a/src/index.js
+++ b/src/index.js
@@ -3,8 +3,4 @@ import print from './js/init'
 
 const printJS = print.init
 
-if (typeof window !== 'undefined') {
-  window.printJS = printJS
-}
-
 export default printJS

--- a/src/index.js
+++ b/src/index.js
@@ -7,4 +7,4 @@ if (typeof window !== 'undefined') {
   window.printJS = printJS
 }
 
-module.exports = printJS
+export default printJS

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,11 +8,12 @@ module.exports = {
     './src/index.js'
   ],
   output: {
-    library: 'print',
+    library: 'printJS',
     libraryTarget: 'umd',
     path: path.resolve(__dirname, 'dist'),
     filename: 'print.js',
-    sourceMapFilename: 'print.map'
+    sourceMapFilename: 'print.map',
+    libraryExport: 'default'
   },
   module: {
     rules: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,7 +8,7 @@ module.exports = {
     './src/index.js'
   ],
   output: {
-    library: 'printJS',
+    library: 'print',
     libraryTarget: 'umd',
     path: path.resolve(__dirname, 'dist'),
     filename: 'print.js',


### PR DESCRIPTION
Expose `printJS` function on the window object (if window exists) (see `/src/index.js`)

Build package via Webpack as a UMD library and purposefully rename
`print` to avoid conflicts.
Update Typescript typings file to reflect this.

Good resources:
http://siawyoung.com/coding/javascript/exporting-es6-modules-as-single-scripts-with-webpack.html
https://webpack.js.org/guides/author-libraries/
https://stackoverflow.com/questions/40294870/module-exports-vs-export-default-in-node-js-and-es6/40295288#40295288