### PR TITLE
add rawHtml type support

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,13 @@ npm install http-server -g
 http-server
 ```
 
+or you can use `live-server`
+
+```
+npm i live-server -g
+live-server
+```
+
 Navigate to `http://localhost:8080/test.html`
 
 

--- a/src/js/init.js
+++ b/src/js/init.js
@@ -4,10 +4,11 @@ import Browser from './browser'
 import Modal from './modal'
 import Pdf from './pdf'
 import Html from './html'
+import RawHtml from './raw_html'
 import Image from './image'
 import Json from './json'
 
-let printTypes = ['pdf', 'html', 'image', 'json']
+let printTypes = ['pdf', 'html', 'rawHtml', 'image', 'json']
 
 export default {
   init () {
@@ -95,8 +96,8 @@ export default {
     if (!params.printable) throw new Error('Missing printable information.')
 
     // Validate type
-    if (!params.type || typeof params.type !== 'string' || printTypes.indexOf(params.type.toLowerCase()) === -1) {
-      throw new Error('Invalid print type. Available types are: pdf, html, image and json.')
+    if (printTypes.indexOf(params.type) === -1) {
+      throw new Error('Invalid print type. Available types are: pdf, html, rawHtml, image and json.')
     }
 
     // Check if we are showing a feedback message to the user (useful for large files)
@@ -166,6 +167,9 @@ export default {
         break
       case 'html':
         Html.print(params, printFrame)
+        break
+      case 'rawHtml':
+        RawHtml.print(params, printFrame)
         break
       case 'json':
         Json.print(params, printFrame)

--- a/src/js/print.js
+++ b/src/js/print.js
@@ -39,6 +39,10 @@ const Print = {
             loadIframeImages(printDocument, params).then(() => {
               finishPrint(iframeElement, params)
             })
+          } else if (params.type === 'rawHtml') {
+            checkIframeImages(printDocument, params).then(() => {
+              finishPrint(iframeElement, params)
+            })
           } else {
             finishPrint(iframeElement, params)
           }
@@ -102,6 +106,19 @@ function finishPrint (iframeElement, params) {
   } finally {
     cleanUp(params)
   }
+}
+
+function checkIframeImages(printDocument, params) {
+    let promises = []
+
+    let images = printDocument.getElementsByTagName('img')
+    for(let i = 0; i < images.length; i++) {
+      let image = images[i]
+      image.setAttribute('id', 'printableImage' + i)
+      promises.push(loadIframeImage(printDocument, i))
+    }
+
+    return Promise.all(promises)
 }
 
 function loadIframeImages (printDocument, params) {

--- a/src/js/raw_html.js
+++ b/src/js/raw_html.js
@@ -1,0 +1,40 @@
+import { collectStyles, loopNodesCollectStyles, addWrapper, addHeader } from './functions'
+import Print from './print'
+
+export default {
+  print: (params, printFrame) => {
+
+    let printableElement = document.createElement('div')
+    printableElement.setAttribute('id', 'printJS-html')
+    printableElement.innerHTML = params.printable
+
+    // Process html styles
+    if (params.scanStyles === true) {
+      // Optional - include margin and padding
+      if (params.honorMarginPadding) params.targetStyles.push('margin', 'padding')
+
+      // Optional - include color
+      if (params.honorColor) params.targetStyles.push('color')
+
+      // Get main element styling
+      printableElement.setAttribute('style', collectStyles(printableElement, params) + 'margin:0 !important;')
+
+      // Get all children elements
+      let elements = printableElement.children
+
+      // Get styles for all children elements
+      loopNodesCollectStyles(elements, params)
+    }
+
+    // Add header
+    if (params.header) {
+      addHeader(printableElement, params.header, params.headerStyle)
+    }
+
+    // Store html data
+    params.htmlData = addWrapper(printableElement.innerHTML, params)
+
+    // Print html element contents
+    Print.send(params, printFrame)
+  }
+}

--- a/test.html
+++ b/test.html
@@ -52,9 +52,19 @@
 
     function printRawHtml() {
         printJS({
-            printable: '<h1>print js is cool</h1><p>it can print raw html</p>',
+            printable: '' +
+            '<h1>print js is cool</h1>' +
+            '<p>it can print raw html</p>' +
+            '<img src="https://avatars0.githubusercontent.com/u/16927940?s=60&v=4" /> '+
+            '<img src="https://avatars0.githubusercontent.com/u/16927940?s=128&v=4" /> '+
+            '<img src="https://avatars0.githubusercontent.com/u/16927940?s=256&v=4" /> '+
+            '<img src="https://avatars0.githubusercontent.com/u/889040?s=64&v=4" /> '+
+            '<img src="https://avatars0.githubusercontent.com/u/889040?s=128&v=4" /> '+
+            '<img src="https://avatars0.githubusercontent.com/u/889040?s=256&v=4" /> '+
+            '<img src="https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png" /> ',
             type: 'rawHtml',
             css: 'test.css',
+            showModal: true,
             scanStyles: false
         });
     }

--- a/test.html
+++ b/test.html
@@ -50,6 +50,15 @@
         });
     }
 
+    function printRawHtml() {
+        printJS({
+            printable: '<h1>print js is cool</h1><p>it can print raw html</p>',
+            type: 'rawHtml',
+            css: 'test.css',
+            scanStyles: false
+        });
+    }
+
     function printJson() {
       let data = [];
       for (let i=0; i <= 1000; i++){
@@ -150,6 +159,9 @@
         </button>
         <button onClick='printHtmlCss();'>
           Print HTML with custom css
+        </button>
+        <button onClick='printRawHtml();'>
+          Print HTML with rawHtml
         </button>
       </p>
       <p>


### PR DESCRIPTION
In some situation, we only have to print the `raw html`, not render the `raw html` on the page.

For example, I am working on a vue project, I just use vue to render the html, but not to mount the element on the page. So I need an api just to print `raw html`.