### PR TITLE
Fix chrome detection

### DIFF
--- a/src/js/browser.js
+++ b/src/js/browser.js
@@ -12,8 +12,8 @@ const Browser = {
     return !Browser.isIE() && !!window.StyleMedia
   },
   // Chrome 1+
-  isChrome: () => {
-    return !!window.chrome && !!window.chrome.webstore
+  isChrome: (context = window) => {
+    return !!context.chrome && !!context.chrome.webstore
   },
   // At least Safari 3+: "[object HTMLElementConstructor]"
   isSafari: () => {

--- a/src/js/browser.js
+++ b/src/js/browser.js
@@ -13,7 +13,7 @@ const Browser = {
   },
   // Chrome 1+
   isChrome: (context = window) => {
-    return !!context.chrome && !!context.chrome.webstore
+    return !!context.chrome
   },
   // At least Safari 3+: "[object HTMLElementConstructor]"
   isSafari: () => {

--- a/test/unit/browser.spec.js
+++ b/test/unit/browser.spec.js
@@ -22,9 +22,14 @@ describe('Browser', () => {
   })
 
   describe('isChrome()', () => {
-    xit('returns true for Google Chrome', () => {
+    it('returns true for Google Chrome', () => {
       const stubbedWindow = { chrome: {} }
       expect(Browser.isChrome(stubbedWindow)).toBeTruthy()
+    })
+
+    it('returns false for non Google Chrome', () => {
+      const stubbedWindow = {}
+      expect(Browser.isChrome(stubbedWindow)).toBeFalsy()
     })
   })
 

--- a/test/unit/browser.spec.js
+++ b/test/unit/browser.spec.js
@@ -21,6 +21,13 @@ describe('Browser', () => {
     expect(typeof Browser.isChrome()).toBe('boolean')
   })
 
+  describe('isChrome()', () => {
+    xit('returns true for Google Chrome', () => {
+      const stubbedWindow = { chrome: {} }
+      expect(Browser.isChrome(stubbedWindow)).toBeTruthy()
+    })
+  })
+
   it('has a function named isSafari that returns a boolean value', () => {
     expect(typeof Browser.isSafari).toBe('function')
     expect(typeof Browser.isSafari()).toBe('boolean')


### PR DESCRIPTION
The `window.chrome` object has no `webstore` property defined.

Closes #256 