### PR TITLE
add a json formatter, so we can format dictionary data in the json to row data.

### DIFF
--- a/src/js/json.js
+++ b/src/js/json.js
@@ -98,11 +98,9 @@ function jsonToHTML (params) {
       } else {
         stringData = stringData[properties[n].field]
       }
-      
       if (properties[n].formatter) {
         stringData = properties[n].formatter(properties[n].field, data[i])
       }
-      
       // Add the row contents and styles
       htmlData += '<td style="width:' + properties[n].columnSize + params.gridStyle + '">' + stringData + '</td>'
     }

--- a/src/js/json.js
+++ b/src/js/json.js
@@ -26,7 +26,8 @@ export default {
       return {
         field: typeof property === 'object' ? property.field : property,
         displayName: typeof property === 'object' ? property.displayName : property,
-        formatter: typeof property === 'object' ? property.formatter : property,
+        // check if valid formatter
+        formatter: typeof property === 'object' && property.formatter && typeof property.formatter === 'function' && property.formatter.length > 2 ? property.formatter : undefined,
         columnSize: typeof property === 'object' && property.columnSize ? property.columnSize + ';' : 100 / params.properties.length + '%;'
       }
     })
@@ -99,7 +100,8 @@ function jsonToHTML (params) {
         stringData = stringData[properties[n].field]
       }
       if (properties[n].formatter) {
-        stringData = properties[n].formatter(properties[n].field, data[i])
+        // formatter(fieldName, row, cellValue, rowIndex)
+        stringData = properties[n].formatter(properties[n].field, data[i], stringData, i)
       }
       // Add the row contents and styles
       htmlData += '<td style="width:' + properties[n].columnSize + params.gridStyle + '">' + stringData + '</td>'

--- a/src/js/json.js
+++ b/src/js/json.js
@@ -1,135 +1,118 @@
-import { addWrapper, capitalizePrint } from "./functions";
-import Print from "./print";
+import {
+  addWrapper,
+  capitalizePrint
+} from './functions'
+import Print from './print'
 
 export default {
   print: (params, printFrame) => {
     // Check if we received proper data
-    if (typeof params.printable !== "object") {
-      throw new Error("Invalid javascript data object (JSON).");
+    if (typeof params.printable !== 'object') {
+      throw new Error('Invalid javascript data object (JSON).')
     }
 
     // Validate repeatTableHeader
-    if (typeof params.repeatTableHeader !== "boolean") {
-      throw new Error("Invalid value for repeatTableHeader attribute (JSON).");
+    if (typeof params.repeatTableHeader !== 'boolean') {
+      throw new Error('Invalid value for repeatTableHeader attribute (JSON).')
     }
 
     // Validate properties
     if (!params.properties || !Array.isArray(params.properties)) {
-      throw new Error("Invalid properties array for your JSON data.");
+      throw new Error('Invalid properties array for your JSON data.')
     }
 
     // We will format the property objects to keep the JSON api compatible with older releases
     params.properties = params.properties.map(property => {
       return {
-        field: typeof property === "object" ? property.field : property,
-        displayName:
-          typeof property === "object" ? property.displayName : property,
-        formatter:
-          typeof property === "object" ? property.formatter : property,
-        columnSize:
-          typeof property === "object" && property.columnSize
-            ? property.columnSize + ";"
-            : 100 / params.properties.length + "%;"
-      };
-    });
+        field: typeof property === 'object' ? property.field : property,
+        displayName: typeof property === 'object' ? property.displayName : property,
+        formatter: typeof property === 'object' ? property.formatter : property,
+        columnSize: typeof property === 'object' && property.columnSize ? property.columnSize + ';' : 100 / params.properties.length + '%;'
+      }
+    })
 
     // Variable to hold the html string
-    let htmlData = "";
+    let htmlData = ''
 
     // Check if there is a header on top of the table
-    if (params.header)
-      htmlData +=
-        '<h1 style="' + params.headerStyle + '">' + params.header + "</h1>";
+    if (params.header) htmlData += '<h1 style="' + params.headerStyle + '">' + params.header + '</h1>'
 
     // Build the printable html data
-    htmlData += jsonToHTML(params);
+    htmlData += jsonToHTML(params)
 
     // Store the data
-    params.htmlData = addWrapper(htmlData, params);
+    params.htmlData = addWrapper(htmlData, params)
 
     // Print the json data
-    Print.send(params, printFrame);
+    Print.send(params, printFrame)
   }
-};
+}
 
-function jsonToHTML(params) {
+function jsonToHTML (params) {
   // Get the row and column data
-  let data = params.printable;
-  let properties = params.properties;
+  let data = params.printable
+  let properties = params.properties
 
   // Create a html table
-  let htmlData = '<table style="border-collapse: collapse; width: 100%;">';
+  let htmlData = '<table style="border-collapse: collapse; width: 100%;">'
 
   // Check if the header should be repeated
   if (params.repeatTableHeader) {
-    htmlData += "<thead>";
+    htmlData += '<thead>'
   }
 
   // Add the table header row
-  htmlData += "<tr>";
+  htmlData += '<tr>'
 
   // Add the table header columns
   for (let a = 0; a < properties.length; a++) {
-    htmlData +=
-      '<th style="width:' +
-      properties[a].columnSize +
-      ";" +
-      params.gridHeaderStyle +
-      '">' +
-      capitalizePrint(properties[a].displayName) +
-      "</th>";
+    htmlData += '<th style="width:' + properties[a].columnSize + ';' + params.gridHeaderStyle + '">' + capitalizePrint(properties[a].displayName) + '</th>'
   }
 
   // Add the closing tag for the table header row
-  htmlData += "</tr>";
+  htmlData += '</tr>'
 
   // If the table header is marked as repeated, add the closing tag
   if (params.repeatTableHeader) {
-    htmlData += "</thead>";
+    htmlData += '</thead>'
   }
 
   // Create the table body
-  htmlData += "<tbody>";
+  htmlData += '<tbody>'
 
   // Add the table data rows
   for (let i = 0; i < data.length; i++) {
     // Add the row starting tag
-    htmlData += "<tr>";
+    htmlData += '<tr>'
 
     // Print selected properties only
     for (let n = 0; n < properties.length; n++) {
-      let stringData = data[i];
+      let stringData = data[i]
 
       // Support nested objects
-      let property = properties[n].field.split(".");
+      let property = properties[n].field.split('.')
       if (property.length > 1) {
         for (let p = 0; p < property.length; p++) {
-          stringData = stringData[property[p]];
+          stringData = stringData[property[p]]
         }
       } else {
-        stringData = stringData[properties[n].field];
+        stringData = stringData[properties[n].field]
       }
-
+      
       if (properties[n].formatter) {
-        stringData = properties[n].formatter(properties[n].field, data[i]);
+        stringData = properties[n].formatter(properties[n].field, data[i])
       }
-
+      
       // Add the row contents and styles
-      htmlData +=
-        '<td style="width:' +
-        properties[n].columnSize +
-        params.gridStyle +
-        '">' +
-        stringData +
-        "</td>";
+      htmlData += '<td style="width:' + properties[n].columnSize + params.gridStyle + '">' + stringData + '</td>'
     }
 
     // Add the row closing tag
-    htmlData += "</tr>";
+    htmlData += '</tr>'
   }
 
   // Add the table and body closing tags
-  htmlData += "</tbody></table>";
+  htmlData += '</tbody></table>'
 
-  return htmlData;
+  return htmlData
 }

--- a/src/js/json.js
+++ b/src/js/json.js
@@ -25,7 +25,7 @@ export default {
         displayName:
           typeof property === "object" ? property.displayName : property,
         formatter:
-          typeof property === "function" ? property.formatter : undefined,
+          typeof property === "object" ? property.formatter : property,
         columnSize:
           typeof property === "object" && property.columnSize
             ? property.columnSize + ";"
@@ -110,8 +110,8 @@ function jsonToHTML(params) {
         stringData = stringData[properties[n].field];
       }
 
-      if (properties[n].formatter) {
-        stringData = properties[n].formatter(properties[n].field, stringData);
+      if (p2roperties[n].formatter) {
+        stringData = properties[n].formatter(properties[n].field, data[i]);
       }
 
       // Add the row contents and styles

--- a/src/js/json.js
+++ b/src/js/json.js
@@ -110,7 +110,7 @@ function jsonToHTML(params) {
         stringData = stringData[properties[n].field];
       }
 
-      if (p2roperties[n].formatter) {
+      if (properties[n].formatter) {
         stringData = properties[n].formatter(properties[n].field, data[i]);
       }
 

--- a/src/js/json.js
+++ b/src/js/json.js
@@ -1,113 +1,135 @@
-import {
-  addWrapper,
-  capitalizePrint
-} from './functions'
-import Print from './print'
+import { addWrapper, capitalizePrint } from "./functions";
+import Print from "./print";
 
 export default {
   print: (params, printFrame) => {
     // Check if we received proper data
-    if (typeof params.printable !== 'object') {
-      throw new Error('Invalid javascript data object (JSON).')
+    if (typeof params.printable !== "object") {
+      throw new Error("Invalid javascript data object (JSON).");
     }
 
     // Validate repeatTableHeader
-    if (typeof params.repeatTableHeader !== 'boolean') {
-      throw new Error('Invalid value for repeatTableHeader attribute (JSON).')
+    if (typeof params.repeatTableHeader !== "boolean") {
+      throw new Error("Invalid value for repeatTableHeader attribute (JSON).");
     }
 
     // Validate properties
     if (!params.properties || !Array.isArray(params.properties)) {
-      throw new Error('Invalid properties array for your JSON data.')
+      throw new Error("Invalid properties array for your JSON data.");
     }
 
     // We will format the property objects to keep the JSON api compatible with older releases
     params.properties = params.properties.map(property => {
       return {
-        field: typeof property === 'object' ? property.field : property,
-        displayName: typeof property === 'object' ? property.displayName : property,
-        columnSize: typeof property === 'object' && property.columnSize ? property.columnSize + ';' : 100 / params.properties.length + '%;'
-      }
-    })
+        field: typeof property === "object" ? property.field : property,
+        displayName:
+          typeof property === "object" ? property.displayName : property,
+        formatter:
+          typeof property === "function" ? property.formatter : undefined,
+        columnSize:
+          typeof property === "object" && property.columnSize
+            ? property.columnSize + ";"
+            : 100 / params.properties.length + "%;"
+      };
+    });
 
     // Variable to hold the html string
-    let htmlData = ''
+    let htmlData = "";
 
     // Check if there is a header on top of the table
-    if (params.header) htmlData += '<h1 style="' + params.headerStyle + '">' + params.header + '</h1>'
+    if (params.header)
+      htmlData +=
+        '<h1 style="' + params.headerStyle + '">' + params.header + "</h1>";
 
     // Build the printable html data
-    htmlData += jsonToHTML(params)
+    htmlData += jsonToHTML(params);
 
     // Store the data
-    params.htmlData = addWrapper(htmlData, params)
+    params.htmlData = addWrapper(htmlData, params);
 
     // Print the json data
-    Print.send(params, printFrame)
+    Print.send(params, printFrame);
   }
-}
+};
 
-function jsonToHTML (params) {
+function jsonToHTML(params) {
   // Get the row and column data
-  let data = params.printable
-  let properties = params.properties
+  let data = params.printable;
+  let properties = params.properties;
 
   // Create a html table
-  let htmlData = '<table style="border-collapse: collapse; width: 100%;">'
+  let htmlData = '<table style="border-collapse: collapse; width: 100%;">';
 
   // Check if the header should be repeated
   if (params.repeatTableHeader) {
-    htmlData += '<thead>'
+    htmlData += "<thead>";
   }
 
   // Add the table header row
-  htmlData += '<tr>'
+  htmlData += "<tr>";
 
   // Add the table header columns
   for (let a = 0; a < properties.length; a++) {
-    htmlData += '<th style="width:' + properties[a].columnSize + ';' + params.gridHeaderStyle + '">' + capitalizePrint(properties[a].displayName) + '</th>'
+    htmlData +=
+      '<th style="width:' +
+      properties[a].columnSize +
+      ";" +
+      params.gridHeaderStyle +
+      '">' +
+      capitalizePrint(properties[a].displayName) +
+      "</th>";
   }
 
   // Add the closing tag for the table header row
-  htmlData += '</tr>'
+  htmlData += "</tr>";
 
   // If the table header is marked as repeated, add the closing tag
   if (params.repeatTableHeader) {
-    htmlData += '</thead>'
+    htmlData += "</thead>";
   }
 
   // Create the table body
-  htmlData += '<tbody>'
+  htmlData += "<tbody>";
 
   // Add the table data rows
   for (let i = 0; i < data.length; i++) {
     // Add the row starting tag
-    htmlData += '<tr>'
+    htmlData += "<tr>";
 
     // Print selected properties only
     for (let n = 0; n < properties.length; n++) {
-      let stringData = data[i]
+      let stringData = data[i];
 
       // Support nested objects
-      let property = properties[n].field.split('.')
+      let property = properties[n].field.split(".");
       if (property.length > 1) {
         for (let p = 0; p < property.length; p++) {
-          stringData = stringData[property[p]]
+          stringData = stringData[property[p]];
         }
       } else {
-        stringData = stringData[properties[n].field]
+        stringData = stringData[properties[n].field];
+      }
+
+      if (properties[n].formatter) {
+        stringData = properties[n].formatter(properties[n].field, stringData);
       }
 
       // Add the row contents and styles
-      htmlData += '<td style="width:' + properties[n].columnSize + params.gridStyle + '">' + stringData + '</td>'
+      htmlData +=
+        '<td style="width:' +
+        properties[n].columnSize +
+        params.gridStyle +
+        '">' +
+        stringData +
+        "</td>";
     }
 
     // Add the row closing tag
-    htmlData += '</tr>'
+    htmlData += "</tr>";
   }
 
   // Add the table and body closing tags
-  htmlData += '</tbody></table>'
+  htmlData += "</tbody></table>";
 
-  return htmlData
+  return htmlData;
 }

--- a/test/manual/index.html
+++ b/test/manual/index.html
@@ -116,6 +116,48 @@
           type: 'json'
         })
     }
+    
+    function printDynamicJson(){
+     let properties = [];
+     properties.push({
+       field: 'test1',
+       displayName: 'name',
+       formatter: "foo" // wrong type
+     },{
+       field: 'test2',
+       displayName: 'age',
+       formatter: function(arg1){
+
+       } // wrong parameter length
+     },{
+       field: 'test3',
+       displayName: 'sex',
+       formatter: function(arg1, args2, args3){
+         return args3
+       }
+     },
+     {
+       field: 'test4',
+       displayName: 'addr'
+     }
+     ) 
+
+     let data=[];
+     for(let i=0; i < 100; i++){
+       data.push({
+         test1: createRandomString(),
+         test2: createRandomString(),
+         test3: createRandomString(),
+         test4: createRandomString()
+       })
+     }
+
+     printJS({
+       printable: data,
+       properties,
+       type: 'json'
+     })
+    }
 
     function createRandomString() {
       var text = "";
@@ -161,6 +203,9 @@
         </button>
         <button onClick='printNestedJson();'>
           Print Nested JSON
+        </button>
+        <button onClick="printDynamicJson();">
+          Print Dynamic JSON
         </button>
       </p>
     </section>


### PR DESCRIPTION
print-js does not support json dictionary data。
So I add a pull request to support it.
example:
json data:
```json
[
   {
        'name':'jhon',
        'sex':'1'
    }
]
```

```js
printJs({
    printable: data,
    properties:[{
         field:'name'
     },
     {
          field:'sex',
          formatter: funtcion(filed, row){ row[field] == '1' ? 'male' : ‘female’ }
     }],
     type: "json"
});
```