### PR TITLE
case browser incompatible

### DIFF
--- a/src/js/init.js
+++ b/src/js/init.js
@@ -31,6 +31,7 @@ export default {
       onLoadingEnd: null,
       onPrintDialogClose: null,
       onPdfOpen: null,
+      onBrowserIncompatible: () => true,
       modalMessage: 'Retrieving Document...',
       frameId: 'printJS',
       htmlData: '',
@@ -76,6 +77,7 @@ export default {
         params.onLoadingEnd = typeof args.onLoadingEnd !== 'undefined' ? args.onLoadingEnd : params.onLoadingEnd
         params.onPrintDialogClose = typeof args.onPrintDialogClose !== 'undefined' ? args.onPrintDialogClose : params.onPrintDialogClose
         params.onPdfOpen = typeof args.onPdfOpen !== 'undefined' ? args.onPdfOpen : params.onPdfOpen
+        params.onBrowserIncompatible = typeof args.onBrowserIncompatible !== 'undefined' ? args.onBrowserIncompatible : params.onBrowserIncompatible;
         params.modalMessage = typeof args.modalMessage !== 'undefined' ? args.modalMessage : params.modalMessage
         params.documentTitle = typeof args.documentTitle !== 'undefined' ? args.documentTitle : params.documentTitle
         params.targetStyle = typeof args.targetStyle !== 'undefined' ? args.targetStyle : params.targetStyle
@@ -147,9 +149,11 @@ export default {
         if (Browser.isFirefox() || Browser.isEdge() || Browser.isIE()) {
           try {
             console.info('PrintJS currently doesn\'t support PDF printing in Firefox, Internet Explorer and Edge.')
-            let win = window.open(params.fallbackPrintable, '_blank')
-            win.focus()
-            if (params.onPdfOpen) params.onPdfOpen()
+            if (params.onBrowserIncompatible() === true) {
+              let win = window.open(params.fallbackPrintable, '_blank')
+              win.focus()
+              if (params.onPdfOpen) params.onPdfOpen()
+            }
           } catch (e) {
             params.onError(e)
           } finally {

--- a/src/js/init.js
+++ b/src/js/init.js
@@ -77,7 +77,7 @@ export default {
         params.onLoadingEnd = typeof args.onLoadingEnd !== 'undefined' ? args.onLoadingEnd : params.onLoadingEnd
         params.onPrintDialogClose = typeof args.onPrintDialogClose !== 'undefined' ? args.onPrintDialogClose : params.onPrintDialogClose
         params.onPdfOpen = typeof args.onPdfOpen !== 'undefined' ? args.onPdfOpen : params.onPdfOpen
-        params.onBrowserIncompatible = typeof args.onBrowserIncompatible !== 'undefined' ? args.onBrowserIncompatible : params.onBrowserIncompatible;
+        params.onBrowserIncompatible = typeof args.onBrowserIncompatible !== 'undefined' ? args.onBrowserIncompatible : params.onBrowserIncompatible
         params.modalMessage = typeof args.modalMessage !== 'undefined' ? args.modalMessage : params.modalMessage
         params.documentTitle = typeof args.documentTitle !== 'undefined' ? args.documentTitle : params.documentTitle
         params.targetStyle = typeof args.targetStyle !== 'undefined' ? args.targetStyle : params.targetStyle

--- a/test/manual/index.html
+++ b/test/manual/index.html
@@ -23,6 +23,17 @@
         });
     }
 
+    function printPdfCompatibleBrowser() {
+      printJS({
+        printable: '/test/manual/test.pdf',
+        type: 'pdf',
+        onBrowserIncompatible: () => {
+          alert('Browser incompatible');
+          return false;
+        }
+      });
+    }
+
     function printHtml() {
       printJS({
         printable: 'test',
@@ -139,6 +150,9 @@
         </button>
         <button onClick='printPdfWithModalAndCloseCallback();'>
           Print PDF with Loading Modal and close callback
+        </button>
+        <button onClick='printPdfCompatibleBrowser();'>
+          Print PDF only on compatible browser
         </button>
       </p>
       <p>


### PR DESCRIPTION
In case of browser incompatible (firefox, edge, IE), possibility to do something and open or not the pdf in new tab. 
 
For example, If onBrowserIncompatible is set, we can display a message like "your browser is incompatible with this feature" and don't open a new tab.