### PR TITLE
Update index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -33,6 +33,7 @@ export interface Configuration {
   onPdfOpen?: () => void;
 }
 
-declare var printJS: (params: string | Configuration) => void;
+declare function printJS(source: string, type?: PrintTypes): void;
+declare function printJS(configuration: Configuration): void;
 
 export default printJS;


### PR DESCRIPTION
Currently can not provide **type** parameter without Typescript complaining about it. Added overloads to the printJS function.