### PR TITLE
Split the table row if the json field value is of type array

### DIFF
--- a/src/js/json.js
+++ b/src/js/json.js
@@ -95,7 +95,13 @@ function jsonToHTML (params) {
       }
 
       // Add the row contents and styles
-      htmlData += '<td style="width:' + properties[n].columnSize + params.gridStyle + '">' + stringData + '</td>'
+      // if the data is of type array, splitting the cell to multiple rows
+      if (typeof stringData === 'object' && stringData.length && stringData.length > 0) {
+        const subTableHtmlData = stringData.reduce((acc, eachRowData) => (acc + '<tr><td style="' + params.gridStyle + '">' + eachRowData + '</td></tr>'), '')
+        htmlData += '<td style="padding:0;width:' + properties[n].columnSize + params.gridStyle + '"><table style="border-collapse: collapse; width: 100%;">' + subTableHtmlData + '</table></td>'
+      } else {
+        htmlData += '<td style="width:' + properties[n].columnSize + params.gridStyle + '">' + stringData + '</td>'
+      }
     }
 
     // Add the row closing tag


### PR DESCRIPTION
Making the table cell to split into multiple rows like in the below image and by sending the field value as array of values.
Ex: 
`const someJSONdata = [
    {
       name: 'John Doe',
       email: ['john@doe.com','john@flash.com'],
       phone: '111-111-1111'
    },
    {
       name: 'Barry Allen',
       email: ['barry@flash.com'],
       phone: '222-222-2222'
    }
 ];
printJS({printable: someJSONdata, properties: ['name', 'email', 'phone'], type: 'json'});
`
![tableExample](https://user-images.githubusercontent.com/5477450/66572477-a9503480-eb8e-11e9-98ab-e1cc342bd06f.JPG)

