### PR TITLE
chrome打印图片时，关闭打印窗口无法触发回调

### DIFF
--- a/src/js/functions.js
+++ b/src/js/functions.js
@@ -76,7 +76,7 @@ export function cleanUp (params) {
   if (params.onPrintDialogClose) {
     let event = 'mouseover'
 
-    if (Browser.isChrome() || Browser.isFirefox()) {
+    if ((Browser.isChrome()&&params.type !== 'image')|| Browser.isFirefox()) {
       // Ps.: Firefox will require an extra click in the document to fire the focus event.
       event = 'focus'
     }


### PR DESCRIPTION
chrome打印image时，关闭打印窗口无法触发回调，因为focus不会回落到window上，只能选择mouseover折中处理