### PR TITLE
use .map in getElementsByTagName is undefined

### DIFF
--- a/src/js/print.js
+++ b/src/js/print.js
@@ -68,11 +68,13 @@ function performPrint (iframeElement, params) {
 }
 
 function loadIframeImages (images) {
-  const promises = images.map(image => {
+  const promises = [];
+  for(let i in images) {
+    let image = images[i];
     if (image.src && image.src !== window.location.href) {
-      return loadIframeImage(image)
+      promises.push(loadIframeImage(image));
     }
-  })
+  }
 
   return Promise.all(promises)
 }


### PR DESCRIPTION
here fix #408 where you can't print if the document is containing img html tag.