### PR TITLE
Add option to not expand nested json objects

### DIFF
--- a/src/js/init.js
+++ b/src/js/init.js
@@ -42,6 +42,7 @@ export default {
       ignoreElements: [],
       imageStyle: 'max-width: 100%;',
       repeatTableHeader: true,
+      expandNestedJsonObjects: true,
       css: null,
       style: null,
       scanStyles: true,

--- a/src/js/json.js
+++ b/src/js/json.js
@@ -82,16 +82,18 @@ function jsonToHTML (params) {
 
     // Print selected properties only
     for (let n = 0; n < properties.length; n++) {
-      let stringData = data[i]
+      let dataEntry = data[i]
+      let stringData = dataEntry[properties[n].field]
 
       // Support nested objects
-      let property = properties[n].field.split('.')
-      if (property.length > 1) {
-        for (let p = 0; p < property.length; p++) {
-          stringData = stringData[property[p]]
+      if (params.expandNestedJsonObjects) {
+        let property = properties[n].field.split('.')
+        if (property.length > 1) {
+          for (let p = 0; p < property.length; p++) {
+            dataEntry = dataEntry[property[p]]
+          }
+          stringData = dataEntry
         }
-      } else {
-        stringData = stringData[properties[n].field]
       }
 
       // Add the row contents and styles


### PR DESCRIPTION
This simply removes the assumption that the `.` character in the field name denotes a nested object.