### PR TITLE
Remote print errors handling

### DIFF
--- a/src/js/pdf.js
+++ b/src/js/pdf.js
@@ -19,6 +19,14 @@ export default {
     let req = new window.XMLHttpRequest()
     req.responseType = 'arraybuffer'
 
+    req.addEventListener('error',() =>{
+        cleanUp(params)
+        params.onError(req.statusText)
+
+        // Since we don't have a pdf document available, we will stop the print job
+        return
+    });
+    
     req.addEventListener('load', () => {
       // Check for errors
       if ([200, 201].indexOf(req.status) === -1) {


### PR DESCRIPTION
Added XmlHttpRequest error event handler.
On remote print errors such as could not find the url. PrintJS does not handle the error