### PR TITLE
fix(performPrint): Ensure `onPrintDialogClose` works in chrome

### DIFF
--- a/src/js/print.js
+++ b/src/js/print.js
@@ -59,6 +59,12 @@ function performPrint (iframeElement, params) {
     } else {
       // Other browsers
       iframeElement.contentWindow.print()
+      
+      // in chrome print call is blocking, meaning the print window is closed when reaching this line
+      if(Browser.isChrome()){
+         // chrome does not raise 'focus' event, hence it needs to be raised manually
+        window.dispatchEvent(new Event("focus"));
+      }      
     }
   } catch (error) {
     params.onError(error)


### PR DESCRIPTION
See https://github.com/crabbly/Print.js/issues/348 for more details