### PR TITLE
Allow use of relative references for pdf

### DIFF
--- a/src/js/pdf.js
+++ b/src/js/pdf.js
@@ -11,7 +11,7 @@ export default {
     }
 
     // Format pdf url
-    params.printable = /^(blob|http)/i.test(params.printable)
+    params.printable = /^(blob|http|\/\/)/i.test(params.printable)
       ? params.printable
       : window.location.origin + (params.printable.charAt(0) !== '/' ? '/' + params.printable : params.printable)
 


### PR DESCRIPTION
This will let the user omit the protocol, e.g.: "//example.com/my.pdf" for "params.printable", and the browser would automatically add the same protocol (http or https) of current url.

https://tools.ietf.org/html/rfc3986#section-4.2