### PR TITLE
Fix `images.map is not a function` error

### DIFF
--- a/src/js/print.js
+++ b/src/js/print.js
@@ -37,7 +37,7 @@ const Print = {
       const images = printDocument.getElementsByTagName('img')
 
       if (images.length > 0) {
-        loadIframeImages(images).then(() => performPrint(iframeElement, params))
+        loadIframeImages(Array.from(images)).then(() => performPrint(iframeElement, params))
       } else {
         performPrint(iframeElement, params)
       }


### PR DESCRIPTION
This is an alternative to #409

Simply ensure `images` is an array before passing to `loadIframeImages`, so it has access to array functions like `map`.