### PR TITLE
fix an IE bug related to Object.keys(styles) that returns an empty array

### DIFF
--- a/src/js/functions.js
+++ b/src/js/functions.js
@@ -18,8 +18,12 @@ export function collectStyles (element, params) {
 
   // Loop over computed styles
   let styles = win.getComputedStyle(element, '')
+  const styleKeys = []
+  for (let i = 0; i < styles.length; i++) {
+    styleKeys.push(i)
+  }
 
-  Object.keys(styles).map(key => {
+  styleKeys.map(key => {
     // Check if style should be processed
     if (params.targetStyles.indexOf('*') !== -1 || params.targetStyle.indexOf(styles[key]) !== -1 || targetStylesMatch(params.targetStyles, styles[key])) {
       if (styles.getPropertyValue(styles[key])) elementStyle += styles[key] + ':' + styles.getPropertyValue(styles[key]) + ';'

--- a/src/js/functions.js
+++ b/src/js/functions.js
@@ -18,17 +18,12 @@ export function collectStyles (element, params) {
 
   // Loop over computed styles
   let styles = win.getComputedStyle(element, '')
-  const styleKeys = []
-  for (let i = 0; i < styles.length; i++) {
-    styleKeys.push(i)
-  }
 
-  styleKeys.map(key => {
-    // Check if style should be processed
+  for (let key = 0; key < styles.length; key++) {
     if (params.targetStyles.indexOf('*') !== -1 || params.targetStyle.indexOf(styles[key]) !== -1 || targetStylesMatch(params.targetStyles, styles[key])) {
       if (styles.getPropertyValue(styles[key])) elementStyle += styles[key] + ':' + styles.getPropertyValue(styles[key]) + ';'
     }
-  })
+  }
 
   // Print friendly defaults
   elementStyle += 'max-width: ' + params.maxWidth + 'px !important;' + params.font_size + ' !important;'

--- a/src/js/functions.js
+++ b/src/js/functions.js
@@ -20,6 +20,7 @@ export function collectStyles (element, params) {
   let styles = win.getComputedStyle(element, '')
 
   for (let key = 0; key < styles.length; key++) {
+    // Check if style should be processed
     if (params.targetStyles.indexOf('*') !== -1 || params.targetStyle.indexOf(styles[key]) !== -1 || targetStylesMatch(params.targetStyles, styles[key])) {
       if (styles.getPropertyValue(styles[key])) elementStyle += styles[key] + ':' + styles.getPropertyValue(styles[key]) + ';'
     }


### PR DESCRIPTION
Hello! I found a problem related to targetStyles in IE. A method getComputedStyle returns an object CSSStyleDeclaration. And in all modern browsers a method `Object.keys(styles)` from this object returns an array of keys like ['0', '1', etc]. But in IE11 `Object.keys(styles)` returns an empty array.

Linked to this issue - https://github.com/crabbly/Print.js/issues/182