### PR TITLE
Firefox PDF support and image printing fix

### DIFF
--- a/src/js/image.js
+++ b/src/js/image.js
@@ -1,5 +1,6 @@
 import { addHeader } from './functions'
 import Print from './print'
+import Browser from './browser'
 
 export default {
   print: (params, printFrame) => {
@@ -20,11 +21,13 @@ export default {
 
       // Set image src with the file url
       img.src = src
-      const fullyQualifiedSrc = img.src
 
-      // Next line is for Firefox, which for some reason requires the image's src to be fully qualified in order to
-      // print it
-      img.src = fullyQualifiedSrc
+      // The following block is for Firefox, which for some reason requires the image's src to be fully qualified in
+      // order to print it
+      if (Browser.isFirefox()) {
+        const fullyQualifiedSrc = img.src
+        img.src = fullyQualifiedSrc
+      }
 
       // Create the image wrapper
       const imageWrapper = document.createElement('div')

--- a/src/js/image.js
+++ b/src/js/image.js
@@ -20,6 +20,11 @@ export default {
 
       // Set image src with the file url
       img.src = src
+      const fullyQualifiedSrc = img.src
+
+      // Next line is for Firefox, which for some reason requires the image's src to be fully qualified in order to
+      // print it
+      img.src = fullyQualifiedSrc
 
       // Create the image wrapper
       const imageWrapper = document.createElement('div')

--- a/src/js/init.js
+++ b/src/js/init.js
@@ -96,10 +96,15 @@ export default {
     // Create a new iframe for the print job
     const printFrame = document.createElement('iframe')
 
-    // Set the iframe to be is visible on the page (guaranteed by fixed position) but hidden using opacity 0, because
-    // this works in Firefox. The height needs to be sufficient for some part of the document other than the PDF
-    // viewer's toolbar to be visible in the page
-    printFrame.setAttribute('style', 'width: 1px; height: 100px; position: fixed; left: 0; top: 0; opacity: 0; border-width: 0; margin: 0; padding: 0')
+    if (Browser.isFirefox()) {
+      // Set the iframe to be is visible on the page (guaranteed by fixed position) but hidden using opacity 0, because
+      // this works in Firefox. The height needs to be sufficient for some part of the document other than the PDF
+      // viewer's toolbar to be visible in the page
+      printFrame.setAttribute('style', 'width: 1px; height: 100px; position: fixed; left: 0; top: 0; opacity: 0; border-width: 0; margin: 0; padding: 0')
+    } else {
+      // Hide the iframe in other browsers
+      printFrame.setAttribute('style', 'visibility: hidden; height: 0; width: 0; position: absolute;')
+    }
 
     // Set iframe element id
     printFrame.setAttribute('id', params.frameId)

--- a/src/js/init.js
+++ b/src/js/init.js
@@ -96,8 +96,10 @@ export default {
     // Create a new iframe for the print job
     const printFrame = document.createElement('iframe')
 
-    // Hide iframe
-    printFrame.setAttribute('style', 'visibility: hidden; height: 0; width: 0; position: absolute;')
+    // Set the iframe to be is visible on the page (guaranteed by fixed position) but hidden using opacity 0, because
+    // this works in Firefox. The height needs to be sufficient for some part of the document other than the PDF
+    // viewer's toolbar to be visible in the page
+    printFrame.setAttribute('style', 'width: 1px; height: 100px; position: fixed; left: 0; top: 0; opacity: 0; border-width: 0; margin: 0; padding: 0')
 
     // Set iframe element id
     printFrame.setAttribute('id', params.frameId)
@@ -124,9 +126,9 @@ export default {
     switch (params.type) {
       case 'pdf':
         // Check browser support for pdf and if not supported we will just open the pdf file instead
-        if (Browser.isFirefox() || Browser.isIE()) {
+        if (Browser.isIE()) {
           try {
-            console.info('PrintJS currently doesn\'t support PDF printing in Firefox and Internet Explorer.')
+            console.info('PrintJS currently doesn\'t support PDF printing in Internet Explorer.')
             if (params.onBrowserIncompatible() === true) {
               const win = window.open(params.fallbackPrintable, '_blank')
               win.focus()

--- a/src/js/print.js
+++ b/src/js/print.js
@@ -29,7 +29,7 @@ const Print = {
       printDocument.body.appendChild(params.printableElement)
 
       // Add custom style
-      if (params.style) {
+      if (params.type !== 'pdf' && params.style) {
         // Create style element
         const style = document.createElement('style')
         style.innerHTML = params.style

--- a/src/js/print.js
+++ b/src/js/print.js
@@ -9,10 +9,41 @@ const Print = {
     // Get iframe element
     const iframeElement = document.getElementById(params.frameId)
 
+    const performPrint = function () {
+      try {
+        iframeElement.focus()
+
+        // If Edge or IE, try catch with execCommand
+        if (Browser.isEdge() || Browser.isIE()) {
+          try {
+            iframeElement.contentWindow.document.execCommand('print', false, null)
+          } catch (e) {
+            iframeElement.contentWindow.print()
+          }
+        } else {
+          // Other browsers
+          iframeElement.contentWindow.print()
+        }
+      } catch (error) {
+        params.onError(error)
+      } finally {
+        // Move the iframe element off-screen and make it invisible
+        iframeElement.style.visibility = 'hidden'
+        iframeElement.style.left = '-1px'
+
+        cleanUp(params)
+      }
+    }
+
     // Wait for iframe to load all content
     iframeElement.onload = () => {
       if (params.type === 'pdf') {
-        performPrint(iframeElement, params)
+        // Add a delay for Firefox. In my tests, 1000ms was sufficient but 100ms was not
+        if (Browser.isFirefox()) {
+          setTimeout(performPrint, 1000)
+        } else {
+          performPrint()
+        }
         return
       }
 
@@ -24,7 +55,7 @@ const Print = {
       printDocument.body.appendChild(params.printableElement)
 
       // Add custom style
-      if (params.type !== 'pdf' && params.style) {
+      if (params.style) {
         // Create style element
         const style = document.createElement('style')
         style.innerHTML = params.style
@@ -37,33 +68,11 @@ const Print = {
       const images = printDocument.getElementsByTagName('img')
 
       if (images.length > 0) {
-        loadIframeImages(Array.from(images)).then(() => performPrint(iframeElement, params))
+        loadIframeImages(Array.from(images)).then(performPrint)
       } else {
-        performPrint(iframeElement, params)
+        performPrint()
       }
     }
-  }
-}
-
-function performPrint (iframeElement, params) {
-  try {
-    iframeElement.focus()
-
-    // If Edge or IE, try catch with execCommand
-    if (Browser.isEdge() || Browser.isIE()) {
-      try {
-        iframeElement.contentWindow.document.execCommand('print', false, null)
-      } catch (e) {
-        iframeElement.contentWindow.print()
-      }
-    } else {
-      // Other browsers
-      iframeElement.contentWindow.print()
-    }
-  } catch (error) {
-    params.onError(error)
-  } finally {
-    cleanUp(params)
   }
 }
 


### PR DESCRIPTION
Add support for printing PDF in Firefox and fix printing of an image with a non-fully-qualified in Firefox. Fixes #431.