### PR TITLE
fix: override default iframe border so it's really hidden

### DIFF
--- a/src/js/init.js
+++ b/src/js/init.js
@@ -103,7 +103,7 @@ export default {
       printFrame.setAttribute('style', 'width: 1px; height: 100px; position: fixed; left: 0; top: 0; opacity: 0; border-width: 0; margin: 0; padding: 0')
     } else {
       // Hide the iframe in other browsers
-      printFrame.setAttribute('style', 'visibility: hidden; height: 0; width: 0; position: absolute;')
+      printFrame.setAttribute('style', 'visibility: hidden; height: 0; width: 0; position: absolute; border: 0')
     }
 
     // Set iframe element id


### PR DESCRIPTION
The issue is that iframes have a default border of 2px, so when printing it's adding a 4x4px at the bottom of the page that in pages using 100vh is an issue because it adds scroll.

iframes default styles:

![image](https://user-images.githubusercontent.com/6024876/93497075-4e7f9b00-f910-11ea-97b4-69bb76ee8418.png)

After printing, at the bottom of the page:

![image](https://user-images.githubusercontent.com/6024876/93497630-ea110b80-f910-11ea-9e86-b637c591bf64.png)

After fix:

![image](https://user-images.githubusercontent.com/6024876/93497653-f301dd00-f910-11ea-8e77-efb2ea50dca7.png)


