### PR TITLE
add missed font-size property

### DIFF
--- a/src/js/functions.js
+++ b/src/js/functions.js
@@ -31,7 +31,7 @@ export function collectStyles (element, params) {
   })
 
   // Print friendly defaults (deprecated)
-  elementStyle += 'max-width: ' + params.maxWidth + 'px !important;' + params.font_size + ' !important;'
+  elementStyle += 'max-width: ' + params.maxWidth + 'px !important; font-size: ' + params.font_size + ' !important;'
 
   return elementStyle
 }


### PR DESCRIPTION
@crabbly Hi again! :) I noticed that I always have wrong property in my styles... Seems to be missed property name. Here it is a new PR from me :)  It's just one small change! Or is it better to remove this part : `params.font_size + ' !important;'` since it is deprecated..
![image](https://user-images.githubusercontent.com/22976204/94261396-18ef3900-ff32-11ea-9aaa-4be8d9604e63.png)
  