### PR TITLE
Feature | Use the XMLHttpRequest instance as second param for `onError` callback

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -27,7 +27,7 @@ declare namespace printJS {
     css?: string | string[];
     style?: string;
     scanStyles?: boolean;
-    onError?: (error: any) => void;
+    onError?: (error: any, xmlHttpRequest?: XMLHttpRequest) => void;
     onPrintDialogClose?: () => void;
     onIncompatibleBrowser?: () => void;
     base64?: boolean;

--- a/src/js/pdf.js
+++ b/src/js/pdf.js
@@ -21,7 +21,7 @@ export default {
 
     req.addEventListener('error', () => {
       cleanUp(params)
-      params.onError(req.statusText)
+      params.onError(req.statusText, req)
 
       // Since we don't have a pdf document available, we will stop the print job
     })
@@ -30,7 +30,7 @@ export default {
       // Check for errors
       if ([200, 201].indexOf(req.status) === -1) {
         cleanUp(params)
-        params.onError(req.statusText)
+        params.onError(req.statusText, req)
 
         // Since we don't have a pdf document available, we will stop the print job
         return


### PR DESCRIPTION
Currently the `onError` callback only has the `req.statusText` field,
as param.

Would be useful to have the `XMLHttpRequest` object instance along
with the `req.statusText`, so we are able to consume all the details
from the request, the response (ArrayBuffer) for instance.

When available the `XMLHttpRequest` instance used in the request
is sent as second param for the `onError` callback.

## Example

Consider the following request to hypothetical site "https://get-a-pdf.com",
where the server responds with a JSON when an error occurs.

We want to consume the JSON in order to print the message to our users.

```ts
printJS({ 
    printable: 'https://get-a-pdf.com',
    type: 'pdf',
    onError: function(error, xmlHttpRequest) {
        // as the `XMLHttpRequest.response` is an instance of
        // `ArrayBuffer` we decode the bytes into UTF-8
        const decoder = new TextDecoder('utf-8');

        handlePDFPrintError(JSON.parse(decoder.decode(xmlHttpRequest.response)));
     }
});
```

This change will also help to access fields like status, so we are able
to consume the status code for particular cases as well.
