### PR TITLE
Bugfix/on close print dialog chrome

### DIFF
--- a/src/js/functions.js
+++ b/src/js/functions.js
@@ -75,7 +75,7 @@ export function cleanUp (params) {
   // Run onPrintDialogClose callback
   let event = 'mouseover'
 
-  if (Browser.isChrome() || Browser.isFirefox()) {
+  if (Browser.isFirefox()) {
     // Ps.: Firefox will require an extra click in the document to fire the focus event.
     event = 'focus'
   }

--- a/src/js/print.js
+++ b/src/js/print.js
@@ -13,7 +13,7 @@ const Print = {
     iframeElement.onload = () => {
       if (params.type === 'pdf') {
         // Add a delay for Firefox. In my tests, 1000ms was sufficient but 100ms was not
-        if (Browser.isFirefox()) {
+        if (Browser.isFirefox() || Browser.isChrome()) {
           setTimeout(() => performPrint(iframeElement, params), 1000)
         } else {
           performPrint(iframeElement, params)

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,7 +14,7 @@ module.exports = {
     libraryTarget: 'umd',
     path: path.resolve(__dirname, 'dist'),
     filename: 'print.js',
-    sourceMapFilename: 'print.map',
+    sourceMapFilename: '[file].map[query]',
     libraryExport: 'default'
   },
   module: {


### PR DESCRIPTION
After updating, Chrome stopped setting focus on the window. In order to track whether the print window has been closed, it is necessary to return a reaction to the mouseover to trigger the callback.