### PR TITLE
Removed deprecated font size

### DIFF
--- a/src/js/functions.js
+++ b/src/js/functions.js
@@ -27,7 +27,7 @@ export function collectStyles (element, params) {
   }
 
   // Print friendly defaults (deprecated)
-  elementStyle += 'max-width: ' + params.maxWidth + 'px !important; font-size: ' + params.font_size + ' !important;'
+  elementStyle += 'max-width: ' + params.maxWidth + 'px !important;'
 
   return elementStyle
 }


### PR DESCRIPTION
Font size from external css files were overridden by inline styles.
- Removed deprecated font-size from functions.js file as the default value given in init.js was getting added to the elements as inline style.  