### PR TITLE
print is async(). In Firefox, cleanUp was resulting in a blank print preview page. …

### DIFF
--- a/src/js/print.js
+++ b/src/js/print.js
@@ -74,7 +74,7 @@ function performPrint (iframeElement, params) {
       iframeElement.style.left = '-1px'
     }
 
-    cleanUp(params)
+    setTimeout(() => cleanUp(params), 100)
   }
 }
 


### PR DESCRIPTION
…This small delay fixes it.