### PR TITLE
fix: added globalObject: 'this' to fix ssr warning for window in umd dist definition

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,7 +15,8 @@ module.exports = {
     path: path.resolve(__dirname, 'dist'),
     filename: 'print.js',
     sourceMapFilename: 'print.map',
-    libraryExport: 'default'
+    libraryExport: 'default',
+    globalObject: 'this'
   },
   module: {
     rules: [


### PR DESCRIPTION
fixes #542 
I hope this fixes it according to https://zenuml.medium.com/window-is-undefined-in-umd-library-output-for-webpack4-858af1b881df
