### PR TITLE
Adds an additional option called "httpHeaders"

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -31,7 +31,7 @@ declare namespace printJS {
     onPrintDialogClose?: () => void;
     onIncompatibleBrowser?: () => void;
     base64?: boolean;
-    httpHeaders?: { [key: string]: string }
+    httpHeaders?: { [key: string]: string };
 
     // Deprecated
     onPdfOpen?: () => void;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -31,6 +31,7 @@ declare namespace printJS {
     onPrintDialogClose?: () => void;
     onIncompatibleBrowser?: () => void;
     base64?: boolean;
+    httpHeaders?: { [key: string]: string }
 
     // Deprecated
     onPdfOpen?: () => void;

--- a/src/js/init.js
+++ b/src/js/init.js
@@ -40,6 +40,7 @@ export default {
       style: null,
       scanStyles: true,
       base64: false,
+      httpHeaders: {},
 
       // Deprecated
       onPdfOpen: null,

--- a/src/js/pdf.js
+++ b/src/js/pdf.js
@@ -41,6 +41,11 @@ export default {
     })
 
     req.open('GET', params.printable, true)
+    if (params.httpHeaders) {
+      for (const [header, value] of Object.entries(params.httpHeaders)) {
+        req.setRequestHeader(header, value)
+      }
+    }
     req.send()
   }
 }


### PR DESCRIPTION
This allows a user to add httpHeaders (for example Authorization header, or Cooke header) when the http request is made for a PDF . 