### PR TITLE
Fix gridHeaderStyle default value

### DIFF
--- a/index.html
+++ b/index.html
@@ -611,7 +611,7 @@
 							</div>
 							<div class="grid-row">
 								<div class="g1">gridHeaderStyle</div>
-								<div class="g1">'font-weight: bold;'</div>
+								<div class="g1">'font-weight: bold; padding: 5px; border: 1px solid #dddddd;'</div>
 								<div class="g2">Optional style for the grid header when printing JSON data.</div>
 							</div>
 							<div class="grid-row">


### PR DESCRIPTION
Looks like it was [changed in the code](https://github.com/crabbly/Print.js/commit/36a03c4ed2d480ed7af26f897eb6405cb21e7d8f) but not in the documentation... :man_shrugging: 