### PR TITLE
Wait for 1 second until the iframe close to avoid printing failure.

### DIFF
--- a/src/js/functions.js
+++ b/src/js/functions.js
@@ -90,7 +90,7 @@ export function cleanUp (params) {
     const iframe = document.getElementById(params.frameId)
 
     if (iframe) {
-      iframe.remove()
+      setTimeout(()=>{iframe.remove()},1000);
     }
   }
 


### PR DESCRIPTION
Wait for 1 second until the iframe close to avoid printing failure.