### PR TITLE
Allow printing PDF from blob

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
     "production": "webpack --mode production --progress --hide-modules",
     "coverage": "open coverage/lcov-report/index.html",
     "coveralls": "cat coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
-		"start": "webpack-dev-server --public http://localhost:8080/test/manual --open",
-		"standard:fix": "standard --fix"
+    "start": "webpack-dev-server --public http://localhost:8080/test/manual --open",
+    "standard:fix": "standard --fix"
   },
   "author": "Rodrigo Vieira <rodrigo@crabbly.com>",
   "standard": {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -31,6 +31,7 @@ declare namespace printJS {
     onPrintDialogClose?: () => void;
     onIncompatibleBrowser?: () => void;
     base64?: boolean;
+    blob?: boolean;
 
     // Deprecated
     onPdfOpen?: () => void;

--- a/src/js/init.js
+++ b/src/js/init.js
@@ -40,6 +40,7 @@ export default {
       style: null,
       scanStyles: true,
       base64: false,
+      blob: false,
 
       // Deprecated
       onPdfOpen: null,

--- a/src/js/pdf.js
+++ b/src/js/pdf.js
@@ -3,6 +3,11 @@ import { cleanUp } from './functions'
 
 export default {
   print: (params, printFrame) => {
+    if (params.blob) {
+      createBlobAndPrint(params, printFrame, params.printable)
+      return
+    }
+
     // Check if we have base64 data
     if (params.base64) {
       const bytesArray = Uint8Array.from(atob(params.printable), c => c.charCodeAt(0))

--- a/test/manual/index.html
+++ b/test/manual/index.html
@@ -37,6 +37,18 @@
       })
     }
 
+    function printPdfBlob() {
+      fetch('/test/manual/test.pdf').then(function(response) {
+        response.blob().then(function(blob) {
+          printJS({
+            printable: blob,
+            type: 'pdf',
+            blob: true
+          })
+        })
+      })
+    }
+
     function printHtml() {
       printJS({
         printable: 'test',
@@ -227,6 +239,9 @@
         </button>
         <button onClick='printPdfBase64();'>
           Print base64 PDF
+        </button>
+        <button onClick='printPdfBlob();'>
+          Print blob PDF
         </button>
       </p>
       <p>


### PR DESCRIPTION
This PR suggests adding an option to print PDF from blob downloaded elsewhere in the application.
This is useful to have a better separation between downloading the document and printing the document. Example use case: disabling the print button when a document starts loading. While it is possible to do with callbacks from printJS, it's much more simple when download and print are separated.