### PR TITLE
Fix Failed to execute 'atob' on 'Window': The string to be decoded is not correctly encoded.

### DIFF
--- a/src/js/pdf.js
+++ b/src/js/pdf.js
@@ -5,6 +5,10 @@ export default {
   print: (params, printFrame) => {
     // Check if we have base64 data
     if (params.base64) {
+        if (params.printable.indexOf(',') !== -1) {
+            //If pdf base64 start with `data:application/pdf;base64,`,Excute the atob function will throw an error.So we get the content after `,`
+            params.printable = params.printable.split(',')[1];
+        }
       const bytesArray = Uint8Array.from(atob(params.printable), c => c.charCodeAt(0))
       createBlobAndPrint(params, printFrame, bytesArray)
       return


### PR DESCRIPTION

[**_privt-js version:1.6.0_**](https://www.npmjs.com/package/print-js/v/1.6.0)

```js
//pdf base64 value start with data:application/pdf;base64,
const pdfBase64 = `data:application/pdf;base64,xxxxxxxxx`;

 printJS({
               printable: pdfBase64,
               base64: true,
            })
```

The above code causes the error **Failed to execute 'atob' on 'Window': The string to be decoded is not correctly encoded.**

Beacuse **atob** function can‘t transfer the symbol(**,**)

So we should remove this symbol.

----------------🎈🎈🎈-----------------

The following file is a pdf base64 string start with `data:application/pdf;base64,`

[base64WithHeader.txt](https://github.com/crabbly/Print.js/files/9496811/base64WithHeader.txt)
