### PR TITLE
Fix PDF printing in Firefox version >= 110

### DIFF
--- a/src/js/browser.js
+++ b/src/js/browser.js
@@ -3,6 +3,14 @@ const Browser = {
   isFirefox: () => {
     return typeof InstallTrigger !== 'undefined'
   },
+  getFirefoxMajorVersion: (userAgent) => {
+    userAgent = userAgent || navigator.userAgent
+    const firefoxVersionRegex = /firefox\/(\S+)/
+    const match = userAgent.toLowerCase().match(firefoxVersionRegex)
+    if (match) {
+      return match[1].split('.').map(x => parseInt(x))[0]
+    }
+  },
   // Internet Explorer 6-11
   isIE: () => {
     return navigator.userAgent.indexOf('MSIE') !== -1 || !!document.documentMode

--- a/src/js/print.js
+++ b/src/js/print.js
@@ -13,7 +13,7 @@ const Print = {
     iframeElement.onload = () => {
       if (params.type === 'pdf') {
         // Add a delay for Firefox. In my tests, 1000ms was sufficient but 100ms was not
-        if (Browser.isFirefox()) {
+        if (Browser.isFirefox() && Browser.getFirefoxMajorVersion() < 110) {
           setTimeout(() => performPrint(iframeElement, params), 1000)
         } else {
           performPrint(iframeElement, params)
@@ -68,7 +68,7 @@ function performPrint (iframeElement, params) {
   } catch (error) {
     params.onError(error)
   } finally {
-    if (Browser.isFirefox()) {
+    if (Browser.isFirefox() && Browser.getFirefoxMajorVersion() < 110) {
       // Move the iframe element off-screen and make it invisible
       iframeElement.style.visibility = 'hidden'
       iframeElement.style.left = '-1px'

--- a/test/unit/browser.spec.js
+++ b/test/unit/browser.spec.js
@@ -5,6 +5,18 @@ describe('Browser', () => {
     expect(typeof Browser.isFirefox).toBe('function')
     expect(typeof Browser.isFirefox()).toBe('boolean')
   })
+  it('has a function named getFirefoxMajorVersion', () => {
+    expect(typeof Browser.getFirefoxMajorVersion).toBe('function')
+  })
+  it('has a function getFirefoxMajorVersion which returns major version from the userAgent string', () => {
+    const userAgents = [
+      'Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/110.0',
+      'Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:25.0) Gecko/20100101 Firefox/29.0',
+      'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36'
+    ]
+    const majorVersions = userAgents.map(userAgent => Browser.getFirefoxMajorVersion(userAgent))
+    expect(majorVersions).toEqual([110, 29, undefined])
+  })
 
   it('has a function named isIE that returns a boolean value', () => {
     expect(typeof Browser.isIE).toBe('function')


### PR DESCRIPTION
* Fixes the issue https://github.com/crabbly/Print.js/issues/655
* Side-effect: speeds up printing in Firefox >= 110 since the wait of 1000 milliseconds is no longer required

### Changes

* Add `getFirefoxMajorVersion` function to the `Browser` module (another alternative would be to use [sniffr](https://www.npmjs.com/package/sniffr), but thought not to add an extra dependency)
* Apply the Firefox-specific workarounds in the `Print` module only for Firefox major versions < 110

### Testing

Tested the changes using `test/manual/index.html` on a Linux machine with Firefox 110.0 and Chrome 109.0.5414.74 