### PR TITLE
'iframeElement.contentWindow.print()' is placed in the setTimeout.

### DIFF
--- a/src/js/print.js
+++ b/src/js/print.js
@@ -59,11 +59,15 @@ function performPrint (iframeElement, params) {
       try {
         iframeElement.contentWindow.document.execCommand('print', false, null)
       } catch (e) {
-        iframeElement.contentWindow.print()
+        setTimeout(function(){
+          iframeElement.contentWindow.print()
+        },1000)
       }
     } else {
       // Other browsers
-      iframeElement.contentWindow.print()
+      setTimeout(function(){
+        iframeElement.contentWindow.print()
+      },1000)
     }
   } catch (error) {
     params.onError(error)


### PR DESCRIPTION
In my project, when the html type is printed, the external font is not displayed. I put' iframeelement. contentwindow.print ()' in the setTimeout.