### PR TITLE
fix: skip loadIframeImage when img tag src attribute is empty

### DIFF
--- a/src/js/print.js
+++ b/src/js/print.js
@@ -84,7 +84,7 @@ function performPrint (iframeElement, params) {
 
 function loadIframeImages (images) {
   const promises = images.map(image => {
-    if (image.src && image.src !== window.location.href) {
+    if (image.getAttribute('src')) {
       return loadIframeImage(image)
     }
   })


### PR DESCRIPTION
When img tag src attribute is empty, if current page URL contains hash symbol, the value of `image.src` and `window.location.href` are not equal.