### PR TITLE
avoid blank page on safari and firefox

### DIFF
--- a/src/js/print.js
+++ b/src/js/print.js
@@ -13,7 +13,7 @@ const Print = {
     iframeElement.onload = () => {
       if (params.type === 'pdf') {
         // Add a delay for Firefox. In my tests, 1000ms was sufficient but 100ms was not
-        if (Browser.isFirefox() && Browser.getFirefoxMajorVersion() < 110) {
+        if (Browser.isFirefox() || Browser.isSafari()) {
           setTimeout(() => performPrint(iframeElement, params), 1000)
         } else {
           performPrint(iframeElement, params)


### PR DESCRIPTION
Blank page issue still occurs with Firefox v114 and Safari. For this reason I propose to add a delay for both browsers and all versions.