### PR TITLE
feat: support documentTitle for PDF printing via document.title guard

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -9,6 +9,7 @@ declare namespace printJS {
     fallbackPrintable?: string;
     type?: PrintTypes;
     documentTitle?: string;
+    documentTitleHoldMs?: number;
     header?: any;
     headerStyle?: string;
     footer?: any;

--- a/src/js/init.js
+++ b/src/js/init.js
@@ -35,6 +35,7 @@ export default {
       frameRemoveDelay: null,
       printableElement: null,
       documentTitle: 'Document',
+      documentTitleHoldMs: 3000,
       targetStyle: ['clear', 'display', 'width', 'min-width', 'height', 'min-height', 'max-height'],
       targetStyles: ['border', 'box', 'break', 'text-decoration'],
       ignoreElements: [],

--- a/src/js/print.js
+++ b/src/js/print.js
@@ -1,6 +1,29 @@
 import Browser from './browser'
 import { cleanUp } from './functions'
 
+function guardDocumentTitle (title, holdMs, onDone) {
+  if (!title) { onDone(); return }
+
+  var originalTitle = document.title
+  document.title = title
+
+  var titleEl = document.querySelector('title')
+  var observer = null
+
+  if (titleEl && typeof MutationObserver !== 'undefined') {
+    observer = new MutationObserver(function () {
+      if (document.title !== title) document.title = title
+    })
+    observer.observe(titleEl, { characterData: true, childList: true, subtree: true })
+  }
+
+  setTimeout(function () {
+    if (observer) observer.disconnect()
+    document.title = originalTitle
+    onDone()
+  }, holdMs)
+}
+
 const Print = {
   send: (params, printFrame) => {
     // Append iframe element to document body
@@ -51,6 +74,16 @@ const Print = {
 }
 
 function performPrint (iframeElement, params) {
+  var isPdfWithTitle = params.type === 'pdf' &&
+    params.documentTitle &&
+    params.documentTitle !== 'Document'
+
+  if (isPdfWithTitle) {
+    guardDocumentTitle(params.documentTitle, params.documentTitleHoldMs || 3000, function () {
+      cleanUp(params)
+    })
+  }
+
   try {
     iframeElement.focus()
 
@@ -59,15 +92,15 @@ function performPrint (iframeElement, params) {
       try {
         iframeElement.contentWindow.document.execCommand('print', false, null)
       } catch (e) {
-        setTimeout(function(){
+        setTimeout(function () {
           iframeElement.contentWindow.print()
-        },1000)
+        }, 1000)
       }
     } else {
       // Other browsers
-      setTimeout(function(){
+      setTimeout(function () {
         iframeElement.contentWindow.print()
-      },1000)
+      }, 1000)
     }
   } catch (error) {
     params.onError(error)
@@ -78,7 +111,9 @@ function performPrint (iframeElement, params) {
       iframeElement.style.left = '-1px'
     }
 
-    cleanUp(params)
+    if (!isPdfWithTitle) {
+      cleanUp(params)
+    }
   }
 }
 

--- a/test/manual/index.html
+++ b/test/manual/index.html
@@ -14,6 +14,30 @@
       })
     }
 
+    function printPdfWithDocumentTitle() {
+      printJS({
+        printable: '/test/manual/test.pdf',
+        type: 'pdf',
+        documentTitle: 'My Custom Report'
+      })
+    }
+
+    function printPdfWithDocumentTitleAndSimulatedReset() {
+      // Simulate a framework (React, Vue, etc.) aggressively resetting document.title
+      var interval = setInterval(function () {
+        document.title = 'RESET BY FRAMEWORK'
+      }, 50)
+
+      // Stop the simulation after 5s so it doesn't run forever
+      setTimeout(function () { clearInterval(interval) }, 5000)
+
+      printJS({
+        printable: '/test/manual/test.pdf',
+        type: 'pdf',
+        documentTitle: 'Guarded Title Test'
+      })
+    }
+
     function printPdfWithModal() {
       printJS({
         printable: '/test/manual/test.pdf',
@@ -288,7 +312,13 @@
         <button onClick='printPdfKioskPrint();'>
           Print PDF In --kiosk-printing Chrome frameRemoveDelay
         </button>
-        
+        <button onClick='printPdfWithDocumentTitle();'>
+          Print PDF with documentTitle
+        </button>
+        <button onClick='printPdfWithDocumentTitleAndSimulatedReset();'>
+          Print PDF with documentTitle (simulated framework reset)
+        </button>
+
       </p>
       <div>
         <h2>Form Elements</h2>


### PR DESCRIPTION
## Summary

- For PDF iframes, Chrome uses `document.title` (not the iframe's `<title>`) for "Save as PDF" filenames. Since `print()` is deferred via `setTimeout`, there's a window between setting the title and Chrome actually reading it — during which a framework (React `<Head>`, Vue router, etc.) can reset it.
- Adds a `MutationObserver`-based guard that holds `document.title` to the desired value across that window, catching and reverting any mutations. Falls back gracefully when `MutationObserver` is unavailable.
- Adds `documentTitleHoldMs` param (default `3000`ms) to let users tune the hold duration.

Closes #487
Closes #66

## Reference

Standalone helper with writeup: https://gist.github.com/danielrose7/adb604b9334118d98de6e856efd043df

## Test plan

Manual test cases are included in `test/manual/index.html` — run `npm start` (or serve the project root) and click:

- **"Print PDF with documentTitle"** — Chrome's save dialog should show "My Custom Report" as the filename
- **"Print PDF with documentTitle (simulated framework reset)"** — aggressively resets `document.title` every 50ms to prove the `MutationObserver` guard holds

Additional checks:
- [ ] Verify non-PDF types (`html`, `image`, `json`) still work as before (no title guard, immediate cleanup)
- [ ] Verify that the original `document.title` is restored after the hold period
- [ ] Test with `documentTitleHoldMs: 500` to verify custom hold durations work

🤖 Generated with [Claude Code](https://claude.com/claude-code)